### PR TITLE
Case and content consistency across Guides' TOC titles and doc titles

### DIFF
--- a/docs/en/toolkit/toolkit_basics_guides/advanced_config.md
+++ b/docs/en/toolkit/toolkit_basics_guides/advanced_config.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Advanced Setup
+title: Configuration setup
 permalink: /toolkit/toolkit_basics_guides/advanced_config/
 lang: en
 ---

--- a/docs/en/toolkit/toolkit_basics_guides/installing_app.md
+++ b/docs/en/toolkit/toolkit_basics_guides/installing_app.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Installing an App
+title: Adding an app
 permalink: /toolkit/toolkit_basics_guides/installing_app/
 lang: en
 ---


### PR DESCRIPTION
 - Guide 1: changed the capitalization of the TOC string, but also changed its content from "Advanced Setup" to "Configuration setup" to better match the title of the doc, "Getting started with configurations"
 - Guide 3: Changed TOC from "Installing an app" to "Adding and app" and fixed capitalization