### PR TITLE
Update landing_page.yml to use UID permalinks

### DIFF
--- a/docs/_data/landing_page.yml
+++ b/docs/_data/landing_page.yml
@@ -9,14 +9,14 @@ image: ./images/landing_page/sg_large_logo.png
 # different tiles to be displayed below headline blurb
 tiles:
 - image: ./images/landing_page/sg.png
-  target: ./shotgun
+  target: ./6dfa5d53
   name: shotgun
 
 - image: ./images/landing_page/tk.png
-  target: ./toolkit
+  target: ./3d1cd26d
   name: toolkit
 
 - image: ./images/landing_page/rv.png
-  target: ./rv
+  target: ./a68c9f18
   name: rv
 


### PR DESCRIPTION
When we switched over to using UID URLs, most internal links could remain relative.  However, because Jekyll generates the landing pages (from the landing_page.yml template) differently, we can't use relative paths here.