### PR TITLE
RV forums now point to Discourse

### DIFF
--- a/docs/_data/en/toc_text.yml
+++ b/docs/_data/en/toc_text.yml
@@ -3,6 +3,7 @@
 # For documentation, see https://developer.shotgunsoftware.com/tk-doc-generator/authoring/toc/
 #
 
+
 rv: RV
 toolkit: Toolkit
 shotgun: Shotgun

--- a/docs/_data/en/toc_text.yml
+++ b/docs/_data/en/toc_text.yml
@@ -3,7 +3,6 @@
 # For documentation, see https://developer.shotgunsoftware.com/tk-doc-generator/authoring/toc/
 #
 
-
 rv: RV
 toolkit: Toolkit
 shotgun: Shotgun

--- a/docs/_data/en/toc_text.yml
+++ b/docs/_data/en/toc_text.yml
@@ -25,6 +25,7 @@ app-development: App Development
 user-manual: User Manual
 technical-reference: Technical Reference
 rv-sdi: RV-SDI
+forums: Forums
 
 maya: Maya
 nuke: Nuke

--- a/docs/_data/toc.yml
+++ b/docs/_data/toc.yml
@@ -78,7 +78,7 @@
     - text: screening-room
       url: "https://support.shotgunsoftware.com/hc/en-us/articles/223949707-What-s-the-difference-between-Screening-Room-and-Shotgun-Review-"
 
-  - text: rv-forums
+  - text: forums
     url: "http://community.shotgunsoftware.com/c/rv"
     
 - caption: quick-answers

--- a/docs/_data/toc.yml
+++ b/docs/_data/toc.yml
@@ -43,7 +43,7 @@
       url: "https://support.shotgunsoftware.com/hc/en-us/articles/360002566514"
   - page: env-config-ref    
   - text: core-api
-    url: " https://developer.shotgunsoftware.com/tk-core/"
+    url: "https://developer.shotgunsoftware.com/tk-core/"
   - page: toolkit-frameworks
     children:
     - text: qt-widgets
@@ -78,13 +78,9 @@
     - text: screening-room
       url: "https://support.shotgunsoftware.com/hc/en-us/articles/223949707-What-s-the-difference-between-Screening-Room-and-Shotgun-Review-"
 
-  - page: rv-forums
-    children:
-    - text: troubleshooting
-      url: "https://support.shotgunsoftware.com/forums/23078637-Questions-and-Troubleshooting-Python-Mu-JavaScript-etc-#recent"
-    - text: extending-rv
-      url: "https://support.shotgunsoftware.com/hc/en-us/community/topics/200682488-RV-Extending-and-Customizing-RV-Python-Mu-JavaScript-etc-#recent"
-
+  - text: rv-forums
+    url: "http://community.shotgunsoftware.com/c/rv"
+    
 - caption: quick-answers
   children:
   - page: quick-answers-administering

--- a/docs/en/rv/forums.md
+++ b/docs/en/rv/forums.md
@@ -1,8 +1,0 @@
----
-layout: default
-title: Forums
-pagename: rv-forums
-lang: en
----
-
-# RV Integrations


### PR DESCRIPTION
Our RV forums are pretty defunct; let's direct people to the RV forum instead. In doing so, got rid of the two links to RV forums (Troubleshooting and Extending) in favor of a single one. 