### PR TITLE
Fix incorrectly quoted page titles in translated pages

### DIFF
--- a/docs/ja/quick-answers/troubleshooting/fix-ssl-certificate-verify-failed.md
+++ b/docs/ja/quick-answers/troubleshooting/fix-ssl-certificate-verify-failed.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Python API で発生する SSL: CERTIFICATE_VERIFY_FAILED の問題の解決
+title: "Python API で発生する SSL: CERTIFICATE_VERIFY_FAILED の問題の解決"
 pagename: fix-ssl-certificate-verify-failed
 lang: ja
 ---

--- a/docs/zh_CN/quick-answers/troubleshooting/fix-ssl-certificate-verify-failed.md
+++ b/docs/zh_CN/quick-answers/troubleshooting/fix-ssl-certificate-verify-failed.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: “解决与 Python API 相关的 SSL: CERTIFICATE_VERIFY_FAILED 问题”
+title: "解决与 Python API 相关的 SSL: CERTIFICATE_VERIFY_FAILED 问题"
 pagename: fix-ssl-certificate-verify-failed
 lang: zh_CN
 ---


### PR DESCRIPTION
Fixes incorrectly quoted titles in translated page names for `fix-ssl-certificate-verify-failed.md`.