### PR TITLE
Changed app to command

### DIFF
--- a/docs/en/quick-answers/developing/maya-shelf-app-launcher.md
+++ b/docs/en/quick-answers/developing/maya-shelf-app-launcher.md
@@ -31,7 +31,7 @@ try:
     # find the current instance of the app.
     # You can print current_engine.commands to list all available commands.
     command = current_engine.commands.get(tk_app) 
-    if not app: 
+    if not command: 
         cmds.error("The Toolkit app '%s' is not available!" % tk_app) 
 
     # now we have the command we need to call the registered callback


### PR DESCRIPTION
prior to the change this would always break because it was checking if app existed and the app variable was never created. so this would break everytime