### PR TITLE
replaced unicode quotes in header with ascii quotes

### DIFF
--- a/docs/ja/quick-answers/troubleshooting/fix-ssl-certificate-verify-failed.md
+++ b/docs/ja/quick-answers/troubleshooting/fix-ssl-certificate-verify-failed.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Python API で発生する SSL: CERTIFICATE_VERIFY_FAILED の問題の解決
+title: "Python API で発生する SSL: CERTIFICATE_VERIFY_FAILED の問題の解決"
 pagename: fix-ssl-certificate-verify-failed
 lang: ja
 ---

--- a/docs/zh_CN/quick-answers/troubleshooting/fix-ssl-certificate-verify-failed.md
+++ b/docs/zh_CN/quick-answers/troubleshooting/fix-ssl-certificate-verify-failed.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: “解决与 Python API 相关的 SSL: CERTIFICATE_VERIFY_FAILED 问题”
+title: "解决与 Python API 相关的 SSL: CERTIFICATE_VERIFY_FAILED 问题"
 pagename: fix-ssl-certificate-verify-failed
 lang: zh_CN
 ---


### PR DESCRIPTION
unicode double quotes in page headers + colon character was breaking yaml and thus the page was not being built. replaced the unicode double quotes with ascii double quotes. slack thread with details (and jokes) here: https://autodesk.slack.com/archives/C14NNUA85/p1573146701077300