### PR TITLE
SG-13614: bundles a new tk-doc-generator that fails properly on jekyll build error

### DIFF
--- a/docs/en/quick-answers/troubleshooting/fix-ssl-certificate-verify-failed.md
+++ b/docs/en/quick-answers/troubleshooting/fix-ssl-certificate-verify-failed.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: "Fixing the SSL: CERTIFICATE_VERIFY_FAILED issues with the Python API"
+title: "Fixing the SSL: "CERTIFICATE_VERIFY_FAILED issues with the Python API"
 pagename: fix-ssl-certificate-verify-failed
 lang: en
 ---

--- a/docs/en/quick-answers/troubleshooting/fix-ssl-certificate-verify-failed.md
+++ b/docs/en/quick-answers/troubleshooting/fix-ssl-certificate-verify-failed.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: "Fixing the SSL: "CERTIFICATE_VERIFY_FAILED issues with the Python API"
+title: "Fixing the SSL: CERTIFICATE_VERIFY_FAILED issues with the Python API"
 pagename: fix-ssl-certificate-verify-failed
 lang: en
 ---


### PR DESCRIPTION
As per the subject. This should cause builds to fail on site-breaking errors that used to end up as warnings from Jekyll.