### PR TITLE
removed "beta" from jira bridge links

### DIFF
--- a/docs/_data/en/toc_text.yml
+++ b/docs/_data/en/toc_text.yml
@@ -20,8 +20,8 @@ python-api: Python API
 rest-api: REST API
 event-triggers: Writing Event-Driven Triggers
 action-menu-items: Creating custom Action Menu Items
-jira-bridge-guide: Sync Data Between Jira and Shotgun (Beta)
-jira-bridge-ref: Jira Bridge Dev Resources (Beta)
+jira-bridge-guide: Sync Data Between Jira and Shotgun
+jira-bridge-ref: Jira Bridge Dev Resources
 examples: Examples
 webinars: Webinar Recordings
 developer-training-videos: Developer Training Videos


### PR DESCRIPTION
jira bridge isn't beta anymore! 