### PR TITLE
SG-20956: Allows for an include to be used for a product name

### DIFF
--- a/docs/_includes/product
+++ b/docs/_includes/product
@@ -1,0 +1,1 @@
+Shotgun


### PR DESCRIPTION
The include will be resolved at build time, and is set to "Shotgun"