### PR TITLE
Add cloudOS VPC to bucket policy tuning

### DIFF
--- a/docs/en/trusted-solutions/tier1/setup/tuning.md
+++ b/docs/en/trusted-solutions/tier1/setup/tuning.md
@@ -59,6 +59,7 @@ We strongly recommend you test media access and media transcoding in your migrat
                 },
                 "StringNotEquals": {
                     "aws:sourceVpc": [
+                        "vpc-2fd62a56",
                         "your_vpc_id"
                     ]
                 }


### PR DESCRIPTION
**Summary**
- Add CloudOS VPC ID to the S3 bucket policy for isolation to account for the scenario where a client's bucket is also in the us-east-1 region.  