### PR TITLE
Add build/deploy for developer.shotgridsoftware.com

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,21 @@ python:
 
 env:
   global:
-    - DOC_URL=https://developer.shotgunsoftware.com
     - DOC_PATH=""
     - S3_BUCKET=sg-devdocs
     - S3_WEB_URL=http://sg-devdocs.s3-website-us-east-1.amazonaws.com
+  jobs:
+    include:
+      # While we're deploying separately to both shotgunsoftware and
+      # shotgridsoftware gh pages, we'll need to run two travis jobs to build
+      # each site correctly.
+      - DOC_URL=https://developer.shotgunsoftware.com
+        REPO_URL=shotgunsoftware/shotgunsoftware.github.io
+      - # We only want to run the second job if the branch is master.
+        if: branch = master
+        env:
+          DOC_URL=https://developer.shotgridsoftware.com
+          REPO_URL=shotgunsoftware/shotgridsoftware.github.io
 
 cache:
   pip: true
@@ -43,7 +54,7 @@ deploy:
   # When commiting to master, auto-deploy to github-pages
   # This will copy the contents of the _build folder to gh-pages branch and push
 - provider: pages
-  repo: shotgunsoftware/shotgunsoftware.github.io
+  repo: $REPO_URL
   local-dir: ./_build
   target-branch: master
   verbose: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,21 +15,22 @@ env:
     - DOC_PATH=""
     - S3_BUCKET=sg-devdocs
     - S3_WEB_URL=http://sg-devdocs.s3-website-us-east-1.amazonaws.com
-  jobs:
-    include:
-      # While we're deploying separately to both shotgunsoftware and
-      # shotgridsoftware gh pages, we'll need to run two travis jobs to build
-      # each site correctly.
-      - name: developer.shotgunsoftware.com
-        env:
-          DOC_URL=https://developer.shotgunsoftware.com
-          REPO_URL=shotgunsoftware/shotgunsoftware.github.io
-      - # We only want to run the second job if the branch is master.
-        if: branch = master
-        name: developer.shotgridsoftware.com
-        env:
-          DOC_URL=https://developer.shotgridsoftware.com
-          REPO_URL=shotgunsoftware/shotgridsoftware.github.io
+
+jobs:
+  include:
+    # While we're deploying separately to both shotgunsoftware and
+    # shotgridsoftware gh pages, we'll need to run two travis jobs to build
+    # each site correctly.
+    - name: developer.shotgunsoftware.com
+      env:
+        DOC_URL=https://developer.shotgunsoftware.com
+        REPO_URL=shotgunsoftware/shotgunsoftware.github.io
+    - # We only want to run the second job if the branch is master.
+      if: branch = master
+      name: developer.shotgridsoftware.com
+      env:
+        DOC_URL=https://developer.shotgridsoftware.com
+        REPO_URL=shotgunsoftware/shotgridsoftware.github.io
 
 cache:
   pip: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,13 @@ env:
       # While we're deploying separately to both shotgunsoftware and
       # shotgridsoftware gh pages, we'll need to run two travis jobs to build
       # each site correctly.
-      - DOC_URL=https://developer.shotgunsoftware.com
-        REPO_URL=shotgunsoftware/shotgunsoftware.github.io
+      - name: developer.shotgunsoftware.com
+        env:
+          DOC_URL=https://developer.shotgunsoftware.com
+          REPO_URL=shotgunsoftware/shotgunsoftware.github.io
       - # We only want to run the second job if the branch is master.
         if: branch = master
+        name: developer.shotgridsoftware.com
         env:
           DOC_URL=https://developer.shotgridsoftware.com
           REPO_URL=shotgunsoftware/shotgridsoftware.github.io

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,8 @@ jobs:
       env:
         DOC_URL=https://developer.shotgunsoftware.com
         REPO_URL=shotgunsoftware/shotgunsoftware.github.io
-    - # We only want to run the second job if the branch is master.
-      if: branch = master
+    - # We only want to run the second job if we are NOT in a PR.
+      if: (branch == master) AND (type != pull_request))
       name: developer.shotgridsoftware.com
       env:
         DOC_URL=https://developer.shotgridsoftware.com


### PR DESCRIPTION
Add appropriate build/deploy for developer.shotgridsoftware.com to Travis CI.

We need to build the site twice since the URL is used during the build process to generate absolute URLs.  Then, while we're continuing to maintain two developer sites, we will need to deploy to both.