### PR TITLE
Specify CNAME when deploying to gh-pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,14 @@ jobs:
       env:
         DOC_URL=https://developer.shotgunsoftware.com
         REPO_URL=shotgunsoftware/shotgunsoftware.github.io
+        CNAME=developer.shotgunsoftware.com
     - # We only want to run the second job if we are NOT in a PR.
       if: (branch == master) AND (type != pull_request)
       name: developer.shotgridsoftware.com
       env:
         DOC_URL=https://developer.shotgridsoftware.com
         REPO_URL=shotgunsoftware/shotgridsoftware.github.io
+        CNAME=developer.shotgridsoftware.com
 
 cache:
   pip: true
@@ -64,6 +66,7 @@ deploy:
   verbose: true
   skip-cleanup: true
   github-token: $GITHUB_TOKEN
+  fqdn: $CNAME
   on:
     # only do this when on the master branch
     branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ jobs:
         DOC_URL=https://developer.shotgunsoftware.com
         REPO_URL=shotgunsoftware/shotgunsoftware.github.io
     - # We only want to run the second job if we are NOT in a PR.
-      if: (branch == master) AND (type != pull_request))
+      if: (branch == master) AND (type != pull_request)
       name: developer.shotgridsoftware.com
       env:
         DOC_URL=https://developer.shotgridsoftware.com

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,0 @@
-developer.shotgunsoftware.com


### PR DESCRIPTION
Previously the CNAME file for Github Pages deploy had been kept as a file in the content repo and pushed through the build into the target repo.  Now that we're targeting multiple site URLs, this approach does not work, so we'll use the `fqdn` option for pages deploy provider to generate a CNAME file for each target appropriately.