### PR TITLE
Small fixes for publish CI

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@4.1.4
         with:
-          branch: master
+          branch: gh-pages
           folder: ./_build
           token: ${{ secrets.TK_GITHUB_TOKEN }}
           repository-name: shotgunsoftware/shotgunsoftware.github.io

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://secure.travis-ci.org/shotgunsoftware/developer.shotgunsoftware.com.svg?branch=master)](http://travis-ci.org/shotgunsoftware/developer.shotgunsoftware.com)
+[![Build Status](https://github.com/shotgunsoftware/developer.shotgunsoftware.com/actions/workflows/publish-docs.yml/badge.svg)](https://github.com/shotgunsoftware/developer.shotgunsoftware.com/actions/workflows/publish-docs.yml)
 [![Doc Generator](https://img.shields.io/badge/Built%20With-SG%20Doc%20Generator-blue.svg)](http://github.com/shotgunsoftware/tk-doc-generator)
 
 


### PR DESCRIPTION
Fixes an issue caused by publishing to the same branch name as the source (master) by changing the publish destination on the GH pages repo to `gh-pages`.  Also updates the CI badge in the `README.md`