### PR TITLE
Fix broken links and malformed md

### DIFF
--- a/.github/workflows/generate-preview.yml
+++ b/.github/workflows/generate-preview.yml
@@ -38,3 +38,8 @@ jobs:
           DOC_PATH:
           PR_NUMBER: ${{ github.event.number }}
         run: python ./tk-doc-generator/actions-generate-docs.py
+      - name: Check for broken links
+        uses: victoriadrake/link-snitch@v1.0.0
+        env:
+          URL: http://sg-devdocs.s3-website-us-east-1.amazonaws.com/tk-doc-generator/${{ GITHUB_SHA }}/
+          FILENAME: ./link_report.yaml


### PR DESCRIPTION
It appears that malformed md and broken links are causing 404s and other build problems.  Attempt to address these problems and prevent them from occurring in the future by adding checks for them in CI.