### PR TITLE
Fix lagging i18n files in trusted-solutions

### DIFF
--- a/docs/ja/trusted-solutions/cloud.md
+++ b/docs/ja/trusted-solutions/cloud.md
@@ -2,14 +2,14 @@
 layout: default
 title: ShotGrid in the Cloud
 pagename: cloud-index
-lang: en
+lang: ja
 ---
 
-# ShotGrid in the Cloud
+# {% include product %} in the Cloud
 
-## What is ShotGrid in the Cloud?
+## What is {% include product %} in the Cloud?
 
-ShotGrid Cloud is our default offering, hosted on AWS and built on top of Autodesk's Cloud technology platform. ShotGrid Cloud is the latest generation of our hosted service and is completely cloud based.
+{% include product %} Cloud is our default offering, hosted on AWS and built on top of Autodesk's Cloud technology platform. {% include product %} Cloud is the latest generation of our hosted service and is completely cloud based.
 
 ## Further Reading
 

--- a/docs/ja/trusted-solutions/tier1.md
+++ b/docs/ja/trusted-solutions/tier1.md
@@ -2,14 +2,14 @@
 layout: default
 title: Isolation Features
 pagename: tier1-index
-lang: en
+lang: ja
 ---
 
 # Isolation Feature Set
 
 ![isolation-theme](./tier1/images/isolation_theme.jpg)
 
-The isolation feature set is an hybrid solution that satisfies strict security and legal requirements, while minimizing ShotGrid System Admin specific required knowledge and maintenance. These features enable creative studios to confidently meet their supplier’s and studio’s highly stringent security, privacy, and performance requirements—from the cloud.
+The isolation feature set is an hybrid solution that satisfies strict security and legal requirements, while minimizing {% include product %} System Admin specific required knowledge and maintenance. These features enable creative studios to confidently meet their supplier’s and studio’s highly stringent security, privacy, and performance requirements—from the cloud.
 
 Continue to [About the isolation feature set](./tier1/getting_started/about.md) for more details.
 
@@ -46,7 +46,7 @@ Go to [Setup](./tier1/setup/setup.md) if you are ready to activate the Isolation
 ### AWS Knowledge
 <!-- When updating this, also update knowledge/knowledge.md -->
 * [Connecting Your Studio With Your AWS VPC](./tier1/knowledge/connecting.md)
-* [ShotGrid AWS Direct Connect Onboarding](./tier1/knowledge/direct_connect_onboarding.md)
+* [{% include product %} AWS Direct Connect Onboarding](./tier1/knowledge/direct_connect_onboarding.md)
 * [S3](./tier1/knowledge/s3.md)
 * [VPC / IAM / Security Group](./tier1/knowledge/vpc_iam_sec.md)
 * [Direct Connect](./tier1/knowledge/direct_connect.md)

--- a/docs/ja/trusted-solutions/tier1/features/features.md
+++ b/docs/ja/trusted-solutions/tier1/features/features.md
@@ -2,7 +2,7 @@
 layout: default
 title: Features Description
 pagename: tier1-features
-lang: en
+lang: ja
 ---
 
 # Isolation Feature Set

--- a/docs/ja/trusted-solutions/tier1/features/media_isolation.md
+++ b/docs/ja/trusted-solutions/tier1/features/media_isolation.md
@@ -2,11 +2,11 @@
 layout: default
 title: Media Isolation
 pagename: tier1-features-media-isolation
-lang: en
+lang: ja
 ---
 
 # Media Isolation
-Media Isolation allows your studio to retain ownership and control of the media and attachments that you upload to ShotGrid. With Media Isolation, all the content that you upload to ShotGrid is stored in your studio's private S3 Bucket. Access to the media is provided to the ShotGrid services only, using [AWS AssumeRole keyless Security Token Service](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html).
+Media Isolation allows your studio to retain ownership and control of the media and attachments that you upload to {% include product %}. With Media Isolation, all the content that you upload to {% include product %} is stored in your studio's private S3 Bucket. Access to the media is provided to the {% include product %} services only, using [AWS AssumeRole keyless Security Token Service](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html).
 
 <img alt="media-isolation-overview" src="../images/media-isolation-overview.png" width="400">
 
@@ -16,13 +16,13 @@ Storing media and attachments in an S3 bucket that you own means that you remain
 <img alt="media-isolation-arch" src="../images/media-isolation-arch.png" width="400">
 
 ## More about Access
-When using ShotGrid to upload and download media it is transferred directly to / from AWS S3 without transiting through Autodesk infrastructure. ShotGrid will only access media in two situations:
-1. The ShotGrid Transcoding service will get read/write access once, soon after upload, when transcoding the media. See [Ephemeral Transcoding](../getting_started/about.md#ephemeral-transcoding) for details.
-2. When the ShotGrid service generates S3 Links to your sources and transcoded media.
+When using {% include product %} to upload and download media it is transferred directly to / from AWS S3 without transiting through Autodesk infrastructure. {% include product %} will only access media in two situations:
+1. The {% include product %} Transcoding service will get read/write access once, soon after upload, when transcoding the media. See [Ephemeral Transcoding](../getting_started/about.md#ephemeral-transcoding) for details.
+2. When the {% include product %} service generates S3 Links to your sources and transcoded media.
 
-This is rendered possible by leveraging [AWS AssumeRole keyless Security Token Service](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html). When setting up Media Isolation, an AWS Role allowing ShotGrid to access your media for the action listed above is created, and the ShotGrid service is allowed to assume that role.
+This is rendered possible by leveraging [AWS AssumeRole keyless Security Token Service](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html). When setting up Media Isolation, an AWS Role allowing {% include product %} to access your media for the action listed above is created, and the {% include product %} service is allowed to assume that role.
 
-ShotGrid Support staff do not have access to your S3 Bucket under any circumstances.
+{% include product %} Support staff do not have access to your S3 Bucket under any circumstances.
 
 ## Costs
 When activating Media Isolation the following costs, previously covered by Autodesk, become the responsibility of the client:
@@ -30,4 +30,4 @@ When activating Media Isolation the following costs, previously covered by Autod
 2. **S3 Bandwidth.** Bandwidth out of the S3 bucket will be assumed by the customer.
 
 ## What Media Isolation is not providing
-Activating Media Isolation doesn't guarantee that the access to your ShotGrid site or media takes place within a closed network. 
+Activating Media Isolation doesn't guarantee that the access to your {% include product %} site or media takes place within a closed network. 

--- a/docs/ja/trusted-solutions/tier1/features/media_replication.md
+++ b/docs/ja/trusted-solutions/tier1/features/media_replication.md
@@ -2,12 +2,12 @@
 layout: default
 title: Media Replication
 pagename: tier1-features-media-replication
-lang: en
+lang: ja
 ---
 
 # Media Replication
 
-ShotGrid is compatible with the S3 Cross-Region replication feature, allowing your users located in different regions to read from the region closer to them in order to reduce latency and increase throughput. Replication to one region is currently supported.
+{% include product %} is compatible with the S3 Cross-Region replication feature, allowing your users located in different regions to read from the region closer to them in order to reduce latency and increase throughput. Replication to one region is currently supported.
 
 <img alt="media-replication-overview" src="../images/media-replication-overview.png" width="400">
 
@@ -15,23 +15,23 @@ ShotGrid is compatible with the S3 Cross-Region replication feature, allowing yo
 Media Isolation is required in order to elect Media Replication.
 
 ## Configuration by users
-When using Media Replication, each user can customize which region data is read from. A user can either specify the region to use, or use automatic mode. In automatic mode ShotGrid selects the replica determined by the user's IP address using IP ranges specified in the Isolation Preferences.
+When using Media Replication, each user can customize which region data is read from. A user can either specify the region to use, or use automatic mode. In automatic mode {% include product %} selects the replica determined by the user's IP address using IP ranges specified in the Isolation Preferences.
 
 <img alt="media-replication-preferences" src="../images/media-replication-preferences.png" width="400">
 
 ## How it works
-ShotGrid can be configured to read from up to two different buckets. Using the [AWS S3 Replication](https://docs.aws.amazon.com/AmazonS3/latest/dev/replication.html) feature, you can configure replication between buckets in different regions, and then consume media from the region closest to your users. It is important to underline that media is always uploaded to the main bucket.
+{% include product %} can be configured to read from up to two different buckets. Using the [AWS S3 Replication](https://docs.aws.amazon.com/AmazonS3/latest/dev/replication.html) feature, you can configure replication between buckets in different regions, and then consume media from the region closest to your users. It is important to underline that media is always uploaded to the main bucket.
 
 <img alt="media-replication-arch" src="../images/media-replication-arch.png" width="400">
 
 Following AWS service level agreement, S3 guarantees the replication of 99.99% of the object within 15 minutes.
 
 ### Replication Delay
-A small amount of time, typically under 15 minutes, is required before replication happens. The replication time depends on the size of the object to replicate. In order to alleviate that replication delay, ShotGrid will, for a small period of time, generate links from to object in the source bucket instead of the replica. The duration of this transitional state in configurable in the Isolation Preferences.
+A small amount of time, typically under 15 minutes, is required before replication happens. The replication time depends on the size of the object to replicate. In order to alleviate that replication delay, {% include product %} will, for a small period of time, generate links from to object in the source bucket instead of the replica. The duration of this transitional state in configurable in the Isolation Preferences.
 
 ## Costs
 Activating the Media Replication feature can increase your AWS costs considerabibly. Before activating, be aware that:
-1. Your S3 cost linked to ShotGrid usage will more or less double, because the media is now stored in two regions.
+1. Your S3 cost linked to {% include product %} usage will more or less double, because the media is now stored in two regions.
 2. You will be charged for the transfer cost between the source and the destination region. See [AWS S3 CRR and the destination region](https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-and-other-bucket-configs.html#replication-and-dest-region) for more details.
 
 ## Next Steps

--- a/docs/ja/trusted-solutions/tier1/features/media_traffic_isolation.md
+++ b/docs/ja/trusted-solutions/tier1/features/media_traffic_isolation.md
@@ -2,7 +2,7 @@
 layout: default
 title: Media Traffic Isolation
 pagename: tier1-features-media-traffic-isolation
-lang: en
+lang: ja
 ---
 
 # Media Traffic Isolation
@@ -15,7 +15,7 @@ Communication between your client systems and S3 bucket targets a number of AWS 
 An S3 Proxy component is deployed within your VPC; which is then used as the endpoint for all S3 communication. It can also be made publicly available using AWS Global Accelerator. 
 
 ## How it works
-ShotGrid can be configured to use an S3 Proxy address to communicate with your S3 bucket. Deploying the S3 Proxy component within your VPC makes it possible to isolate traffic from the public Internet completely, or to allow more tightly controlled access from the Internet to your media.
+{% include product %} can be configured to use an S3 Proxy address to communicate with your S3 bucket. Deploying the S3 Proxy component within your VPC makes it possible to isolate traffic from the public Internet completely, or to allow more tightly controlled access from the Internet to your media.
 
 <img alt="media-traffic-isolation-arch" src="../images/media-traffic-isolation-arch.png" width="400">
 

--- a/docs/ja/trusted-solutions/tier1/features/web_traffic_isolation.md
+++ b/docs/ja/trusted-solutions/tier1/features/web_traffic_isolation.md
@@ -2,12 +2,12 @@
 layout: default
 title: Web Traffic Isolation
 pagename: tier1-features-web-traffic-isolation
-lang: en
+lang: ja
 ---
 
 # Web Traffic Isolation
 
-Communication between your client systems and your ShotGrid site will traverse the open Internet by default. Web Traffic Isolation allows you to restrict access to your ShotGrid site from the public Internet entirely and ensure that all traffic transits directly between your AWS VPC and Autodesk's AWS VPC.
+Communication between your client systems and your {% include product %} site will traverse the open Internet by default. Web Traffic Isolation allows you to restrict access to your {% include product %} site from the public Internet entirely and ensure that all traffic transits directly between your AWS VPC and Autodesk's AWS VPC.
 
 <img alt="web-traffic-isolation-overview" src="../images/web-traffic-isolation-overview.png" width="400">
 

--- a/docs/ja/trusted-solutions/tier1/getting_started/about.md
+++ b/docs/ja/trusted-solutions/tier1/getting_started/about.md
@@ -2,12 +2,12 @@
 layout: default
 title: About the Isolation Feature Set
 pagename: tier1-getting_started-about
-lang: en
+lang: ja
 ---
 
 # What is the Isolation Feature Set
 
-The isolation feature set combines our Cloud Hosted Platform with client-managed AWS resources to provide a solution that satisfies the most stringent security and privacy requirements. Clients retain control of their sensitive content without having to host ShotGrid on their infrastructure.
+The isolation feature set combines our Cloud Hosted Platform with client-managed AWS resources to provide a solution that satisfies the most stringent security and privacy requirements. Clients retain control of their sensitive content without having to host {% include product %} on their infrastructure.
 
 Leveraging the isolation feature set has the following advantages over the Standard offering:
 
@@ -15,28 +15,28 @@ Leveraging the isolation feature set has the following advantages over the Stand
 * **Web Traffic Isolation** from the public internet
 * **Media Traffic Isolation** from the public internet
 * **Media Replication** allowing you to replicate media in one additional AWS Region
-* Access to fully managed ShotGrid Cloud Services
+* Access to fully managed {% include product %} Cloud Services
 * Automatic and continuous version upgrades
 * Ephemeral compute + in-memory segration between clients
 
-In a nutshell, this means that with the isolation features, your ShotGrid site and the data related to it cannot be reached by anyone outside of your studio network.
+In a nutshell, this means that with the isolation features, your {% include product %} site and the data related to it cannot be reached by anyone outside of your studio network.
 
-The isolation feature set is a solution that requires less upkeep, as well as less IT/System Administrator knowledge and skills, than hosting ShotGrid on-premise. The list of advantages compared to on-premise includes, but is not limited to:
+The isolation feature set is a solution that requires less upkeep, as well as less IT/System Administrator knowledge and skills, than hosting {% include product %} on-premise. The list of advantages compared to on-premise includes, but is not limited to:
 
-* No ShotGrid specific knowledge required
-* No manual ShotGrid updates required
+* No {% include product %} specific knowledge required
+* No manual {% include product %} updates required
 * Very low level of maintenance required for the AWS components
 
 ## Media isolation feature
-Media Isolation allows your studio to keep the ownership and control of the media and attachments that you upload to ShotGrid. With Media Isolation, all the content that you upload to ShotGrid can be store in your studio private S3 bucket. Access to the media is provided to the ShotGrid service only, using AWS AssumeRole keyless Security Token Service. Your studio remains in control of the assets and the access to the assets, access that you can revoke at will.
+Media Isolation allows your studio to keep the ownership and control of the media and attachments that you upload to {% include product %}. With Media Isolation, all the content that you upload to {% include product %} can be store in your studio private S3 bucket. Access to the media is provided to the {% include product %} service only, using AWS AssumeRole keyless Security Token Service. Your studio remains in control of the assets and the access to the assets, access that you can revoke at will.
 
 ## Traffic isolation features
-Media and Web traffic isolation features can be enabled to prevent your traffic from being routed on the public internet, limiting it to the AWS backbone and your studio network. The traffic between ShotGrid Services and your studio stays in closed network, never going outside AWS or your Studio network.
+Media and Web traffic isolation features can be enabled to prevent your traffic from being routed on the public internet, limiting it to the AWS backbone and your studio network. The traffic between {% include product %} Services and your studio stays in closed network, never going outside AWS or your Studio network.
 
 With the Media Traffic Isolation feature activated, the media will only leave your studio infrastructure once to get transcoded.
 
 ## Media Replication
-ShotGrid is compatible with the S3 Cross-Region replication feature, allowing your users located in different regions to read from the region closer to them in order to reduce latency and increase throughput. Replication to one region is currently supported.
+{% include product %} is compatible with the S3 Cross-Region replication feature, allowing your users located in different regions to read from the region closer to them in order to reduce latency and increase throughput. Replication to one region is currently supported.
 
 
 # Eligibility
@@ -46,26 +46,26 @@ The Isolation feature set is available for all Super Awesome clients. See [Getti
 
 # What the Isolation Feature Set is not
 
-The isolation feature set is not a completely isolated solution. Both the compute services and the database services are shared amongst clients, and managed by ShotGrid. From a hardware standpoint, the isolation features does not guarantee complete physical isolation. However, ShotGrid services are guaranteeing isolation at the memory level. Processes are never reused to answer requests from different clients during their lifetime. Client metadata is stored in different databases. Client media is individually stored on S3.
+The isolation feature set is not a completely isolated solution. Both the compute services and the database services are shared amongst clients, and managed by {% include product %}. From a hardware standpoint, the isolation features does not guarantee complete physical isolation. However, {% include product %} services are guaranteeing isolation at the memory level. Processes are never reused to answer requests from different clients during their lifetime. Client metadata is stored in different databases. Client media is individually stored on S3.
 
 
 # High Level Architecture
 ![tier1-arch](../images/tier1-about-arch.png)
 
-The ShotGrid cloud service  can be decoupled at a high level in 3 parts:
+The {% include product %} cloud service  can be decoupled at a high level in 3 parts:
 
-**Compute Stack:** The part of the ShotGrid Service that handles client requests and serves data to the client.
+**Compute Stack:** The part of the {% include product %} Service that handles client requests and serves data to the client.
 
 **Data Stack:** Metadata storage (databases).
 
-**Media Storage:** Where the client's attachments, media, and assets are stored. ShotGrid uses AWS S3 to store client content.
+**Media Storage:** Where the client's attachments, media, and assets are stored. {% include product %} uses AWS S3 to store client content.
 
-Please read [Securing Studio IP in AWS: Cloud-based VFX Project Management with Autodesk ShotGrid](https://aws.amazon.com/blogs/media/securing-studio-ip-in-aws-cloud-based-vfx-project-management-with-autodesk-shotgun/) for more details about the architecture.
+Please read [Securing Studio IP in AWS: Cloud-based VFX Project Management with Autodesk {% include product %}](https://aws.amazon.com/blogs/media/securing-studio-ip-in-aws-cloud-based-vfx-project-management-with-autodesk-shotgun/) for more details about the architecture.
 
 ## Ephemeral compute and memory isolation
-Even if clients share the same infrastructure, ShotGrid guarantees a complete memory isolation, both in transit and at rest, of client data. This makes ShotGrid less prone to data leaking due to architecture flaws or software vulnerabilities exploiting memory, like buffer overflow.
+Even if clients share the same infrastructure, {% include product %} guarantees a complete memory isolation, both in transit and at rest, of client data. This makes {% include product %} less prone to data leaking due to architecture flaws or software vulnerabilities exploiting memory, like buffer overflow.
 
 ## Ephemeral transcoding
 ![tier1-transcoding](../images/tier1-about-transcoding.png)
 
-Everytime media is uploaded to ShotGrid, the transcoding service is invoked to create a web friendly versions of your assets. That process happens only once, after the initial upload. The media is directly uploaded from the client to S3, from where it is fetched by the ShotGrid Transcoding Service. Each transcoding job is handled by a single container, which is killed after that unique job. The only place the media temporarily lives is in the container memory. The ShotGrid Transcoding service doesn't store permanently a copy of your media.
+Everytime media is uploaded to {% include product %}, the transcoding service is invoked to create a web friendly versions of your assets. That process happens only once, after the initial upload. The media is directly uploaded from the client to S3, from where it is fetched by the {% include product %} Transcoding Service. Each transcoding job is handled by a single container, which is killed after that unique job. The only place the media temporarily lives is in the container memory. The {% include product %} Transcoding service doesn't store permanently a copy of your media.

--- a/docs/ja/trusted-solutions/tier1/getting_started/getting_started.md
+++ b/docs/ja/trusted-solutions/tier1/getting_started/getting_started.md
@@ -2,7 +2,7 @@
 layout: default
 title: Getting Started
 pagename: tier1-getting_started
-lang: en
+lang: ja
 ---
 
 # Isolation Feature Set - Getting Started

--- a/docs/ja/trusted-solutions/tier1/getting_started/onboarding.md
+++ b/docs/ja/trusted-solutions/tier1/getting_started/onboarding.md
@@ -2,7 +2,7 @@
 layout: default
 title: Onboarding Process
 pagename: tier1-getting_started-onboarding
-lang: en
+lang: ja
 ---
 
 # Onboarding Process
@@ -11,7 +11,7 @@ Leveraging the isolation features requires adopters to become AWS users. In orde
 
 Autodesk and Amazon will provide dedicated resources during the onboarding process to help you on this journey.
 
-To start the on-boarding process for any of the Isolation features, please open a [ShotGrid Support ticket](https://support.shotgunsoftware.com/hc/en-us/requests/new), before proceeding with [your setup](../setup/setup.md)
+To start the on-boarding process for any of the Isolation features, please open a [{% include product %} Support ticket](https://support.shotgunsoftware.com/hc/en-us/requests/new), before proceeding with [your setup](../setup/setup.md)
 
 ## Onboarding Process Overview
 
@@ -23,19 +23,19 @@ During the onboarding process, you'll have direct access to Autodesk and AWS Lea
 
 **Tech Deep Dive:**  OPTIONAL. Deeper technical dive into isolation features. This meeting can be combined with the Tech Briefing.
 
-**Kickoff Meeting:**	AWS and ShotGrid Leaders review the setup process with the you.
+**Kickoff Meeting:**	AWS and {% include product %} Leaders review the setup process with the you.
 
-**Setup / Test / Validation:**	Iterative installation process where you connect your AWS resources to ShotGrid, and activate the isolation features.
+**Setup / Test / Validation:**	Iterative installation process where you connect your AWS resources to {% include product %}, and activate the isolation features.
 
-**Training:** OPTIONAL. Help sessions, if needed, as you ramp up on the AWS/ShotGrid technologies required to securely set-up the isolation features for your site.
+**Training:** OPTIONAL. Help sessions, if needed, as you ramp up on the AWS/{% include product %} technologies required to securely set-up the isolation features for your site.
 
 ## Onboarding Resources
 
-**ShotGrid Community:** The [ShotGrid Isolation Community](https://community.shotgunsoftware.com/c/trusted-solutions/isolation/34) forum can be used to ask questions that can be answered by either ShotGrid Experts or other isolation features users. This should be your first stop when asking general questions about isolation features, during setup and beyond.
+**{% include product %} Community:** The [{% include product %} Isolation Community](https://community.shotgridsoftware.com/c/trusted-solutions/isolation/34) forum can be used to ask questions that can be answered by either {% include product %} Experts or other isolation features users. This should be your first stop when asking general questions about isolation features, during setup and beyond.
 
-**Private Slack Channel:** During the onboarding, you will be given access to a dedicated Autodesk Slack Channel. Your ShotGrid and AWS Leaders will be available for quick feedback, answers, and ad-hoc meetings to help you progress as fast as possible with your ShotGrid Isolation setup. This channel will be available only for the onboarding period.
+**Private Slack Channel:** During the onboarding, you will be given access to a dedicated Autodesk Slack Channel. Your {% include product %} and AWS Leaders will be available for quick feedback, answers, and ad-hoc meetings to help you progress as fast as possible with your {% include product %} Isolation setup. This channel will be available only for the onboarding period.
 
-**ShotGrid Support:** A [ShotGrid Support](https://support.shotgunsoftware.com/hc/en-us/requests/new) ticket will be used to track your onboarding at a higher level. Once your ShotGrid Isolation setup is complete, follow-up support tickets can be opened with the support team as needed.
+**{% include product %} Support:** A [{% include product %} Support](https://support.shotgunsoftware.com/hc/en-us/requests/new) ticket will be used to track your onboarding at a higher level. Once your {% include product %} Isolation setup is complete, follow-up support tickets can be opened with the support team as needed.
 
 ## Next Steps
 

--- a/docs/ja/trusted-solutions/tier1/getting_started/responsibilities.md
+++ b/docs/ja/trusted-solutions/tier1/getting_started/responsibilities.md
@@ -2,7 +2,7 @@
 layout: default
 title: Client Responsibilities
 pagename: tier1-getting_started-responsibilities
-lang: en
+lang: ja
 ---
   
 # Client Responsibilities
@@ -15,7 +15,7 @@ You are entirely responsible for the validity, security, and execution of the Is
  
 Autodesk is available during the process for assistance, but the configuration of Isolation features in Your AWS Account is to be executed by You on Your own.
 
-Isolation feature set activation requires the ShotGrid Support team's intervention. Activation delays are to be expected and will depend on demand. You understand that an estimated period of 2-8 weeks is usually required to complete the setup necessary to implement the isolation feature set. The setup time is highly dependent on your cooperation, so please plan to dedicate resources for the setup before beginning the onboarding process.
+Isolation feature set activation requires the {% include product %} Support team's intervention. Activation delays are to be expected and will depend on demand. You understand that an estimated period of 2-8 weeks is usually required to complete the setup necessary to implement the isolation feature set. The setup time is highly dependent on your cooperation, so please plan to dedicate resources for the setup before beginning the onboarding process.
 
 Autodesk does not guarantee any timeline for setup completion.
 
@@ -24,13 +24,13 @@ Autodesk does not guarantee any timeline for setup completion.
 |Type|	Description / Agreement |	Responsibility	| Available for Assistance|
 |--------|-----|----------|---------|
 |AWS Knowledge	|	Acquiring the AWS-specific knowledge required to set up the isolation features.	|You	|N/A|
-|S3|Setting up the S3 Bucket that will host Your media Securing access to the S3 Bucket. Additional high-availability measures (versioning, bucket replication, etc.)	|You	|ShotGrid and *AWS|
+|S3|Setting up the S3 Bucket that will host Your media Securing access to the S3 Bucket. Additional high-availability measures (versioning, bucket replication, etc.)	|You	|{% include product %} and *AWS|
 |Closed VPC	|Setting up DirectConnect/VPN, etc. to allow closed access to the VPC. Securing the VPC by putting the correct Security Groups in place.	|You	|*AWS |
-|Media Isolation	|Creating the S3 end-points. Deploying the S3 Proxy.	|You|	ShotGrid and *AWS |
-|Traffic Isolation	|Creating VPCs. Creating Subnets.|	You|ShotGrid|
-|Private Access Point|Checking that the access point is only available from Your network.|	ShotGrid|	N/A|
-|Monitoring and Reliability|Maintaining uptime up to Autodesk standards. High availability and redundancy of Cloud Services. Metadata and database resiliency and redundancy. Maintaining Recovery Point Objective (RPO) for metadata and database.	|ShotGrid|N/A|
-|Service Level Objective|Maintaining ShotGrid target RPO and RTO (See [ShotGrid Security White Paper](https://support.shotgunsoftware.com/hc/en-us/articles/114094526153-Shotgun-security-white-paper) for more details).|ShotGrid|	N/A|
-|Security and Governance |Maintaining the ShotGrid Cloud Services that Isolation clients are interfacing with, so that they are meeting expectations in terms of security, vulnerability patching, scanning, auditing, etc. (See [ShotGrid Security White Paper](https://support.shotgunsoftware.com/hc/en-us/articles/114094526153-Shotgun-security-white-paper) for more details).|	ShotGrid	|N/A|
+|Media Isolation	|Creating the S3 end-points. Deploying the S3 Proxy.	|You|	{% include product %} and *AWS |
+|Traffic Isolation	|Creating VPCs. Creating Subnets.|	You|{% include product %}|
+|Private Access Point|Checking that the access point is only available from Your network.|	{% include product %}|	N/A|
+|Monitoring and Reliability|Maintaining uptime up to Autodesk standards. High availability and redundancy of Cloud Services. Metadata and database resiliency and redundancy. Maintaining Recovery Point Objective (RPO) for metadata and database.	|{% include product %}|N/A|
+|Service Level Objective|Maintaining {% include product %} target RPO and RTO (See [{% include product %} Security White Paper](https://support.shotgunsoftware.com/hc/en-us/articles/114094526153-Shotgun-security-white-paper) for more details).|{% include product %}|	N/A|
+|Security and Governance |Maintaining the {% include product %} Cloud Services that Isolation clients are interfacing with, so that they are meeting expectations in terms of security, vulnerability patching, scanning, auditing, etc. (See [{% include product %} Security White Paper](https://support.shotgunsoftware.com/hc/en-us/articles/114094526153-Shotgun-security-white-paper) for more details).|	{% include product %}	|N/A|
 
 *You are solely responsible to seek or obtain any support services AWS may provide under any existing relationship between You and AWS. Autodesk teams are not parties to Your relationship with AWS and therefore not responsible or liable for any services or lack thereof provided by AWS to You. 

--- a/docs/ja/trusted-solutions/tier1/knowledge/aws.md
+++ b/docs/ja/trusted-solutions/tier1/knowledge/aws.md
@@ -2,7 +2,7 @@
 layout: default
 title: AWS Knowledge
 pagename: tier1-knowledge-aws
-lang: en
+lang: ja
 ---
 
 # AWS Knowledge

--- a/docs/ja/trusted-solutions/tier1/knowledge/connecting.md
+++ b/docs/ja/trusted-solutions/tier1/knowledge/connecting.md
@@ -2,7 +2,7 @@
 layout: default
 title: Connecting Your Studio With Your AWS VPC
 pagename: tier1-knowledge-connecting
-lang: en
+lang: ja
 ---
 
 # Connecting Your Studio With Your AWS VPC

--- a/docs/ja/trusted-solutions/tier1/knowledge/direct_connect.md
+++ b/docs/ja/trusted-solutions/tier1/knowledge/direct_connect.md
@@ -2,7 +2,7 @@
 layout: default
 title: Direct Connect
 pagename: tier1-knowledge-direct_connect
-lang: en
+lang: ja
 ---
 
 # Direct Connect

--- a/docs/ja/trusted-solutions/tier1/knowledge/direct_connect_onboarding.md
+++ b/docs/ja/trusted-solutions/tier1/knowledge/direct_connect_onboarding.md
@@ -2,9 +2,10 @@
 layout: default
 title: ShotGrid AWS Direct Connect Onboarding
 pagename: tier1-knowledge-direct_connect_onboarding
+lang: ja
 ---
 
-# ShotGrid AWS Direct Connect Onboarding
+# {% include product %} AWS Direct Connect Onboarding
 
 
 ## Introduction
@@ -40,7 +41,7 @@ If you answer “yes” to the following, then request a dedicated Direct Connec
 
 If you answer “yes” to the following, then request a dedicated Direct Connect connection through the AWS Console and select a Partner to assist (Option 1b):
 
-- Are you planning to use AWS Direct Connect to connect to other AWS resources outside of ShotGrid?
+- Are you planning to use AWS Direct Connect to connect to other AWS resources outside of {% include product %}?
 - Do you have the time and resources to complete the setup?
 - Are you looking for any one of the following - 1Gbps, 10Gbps port, or a dedicated connection?
 

--- a/docs/ja/trusted-solutions/tier1/knowledge/endpoints.md
+++ b/docs/ja/trusted-solutions/tier1/knowledge/endpoints.md
@@ -2,7 +2,7 @@
 layout: default
 title: VPC Endpoints
 pagename: tier1-knowledge-endpoints
-lang: en
+lang: ja
 ---
 
 # VPC Endpoints

--- a/docs/ja/trusted-solutions/tier1/knowledge/knowledge.md
+++ b/docs/ja/trusted-solutions/tier1/knowledge/knowledge.md
@@ -2,7 +2,7 @@
 layout: default
 title: Knowledge
 pagename: tier1-knowledge
-lang: en
+lang: ja
 ---
 
 # Generic Knowledge
@@ -10,7 +10,7 @@ lang: en
 ## In This Section
 <!-- When updating this, also update tier1.md -->
 * [Connecting Your Studio With Your AWS VPC](./connecting.md)
-* [ShotGrid AWS Direct Connect Onboarding](./direct_connect_onboarding.md)
+* [{% include product %} AWS Direct Connect Onboarding](./direct_connect_onboarding.md)
 * [S3](./s3.md)
 * [VPC / IAM / Security Group](./vpc_iam_sec.md)
 * [Direct Connect](./direct_connect.md)

--- a/docs/ja/trusted-solutions/tier1/knowledge/private_link.md
+++ b/docs/ja/trusted-solutions/tier1/knowledge/private_link.md
@@ -2,11 +2,11 @@
 layout: default
 title: Private Link
 pagename: tier1-knowledge-private_link
-lang: en
+lang: ja
 ---
 
 # Private Link
 
 [AWS PrivateLink](https://aws.amazon.com/privatelink/) is an AWS service that connects different AWS VPCs without going through the public internet. 
 
-In conjunction with [AWS Direct Connect](./direct_connect.md), PrivateLink helps create a dedicated connection between your studio and ShotGrid's infrastructure.
+In conjunction with [AWS Direct Connect](./direct_connect.md), PrivateLink helps create a dedicated connection between your studio and {% include product %}'s infrastructure.

--- a/docs/ja/trusted-solutions/tier1/knowledge/s3.md
+++ b/docs/ja/trusted-solutions/tier1/knowledge/s3.md
@@ -2,11 +2,11 @@
 layout: default
 title: S3
 pagename: tier1-knowledge-s3
-lang: en
+lang: ja
 ---
 
 # S3
 
-[Amazon S3](https://aws.amazon.com/s3/) is an object storage service offered by AWS. It can be thought of as a highly durable storage space in the cloud. ShotGrid uses S3 to store uploaded media and files.
+[Amazon S3](https://aws.amazon.com/s3/) is an object storage service offered by AWS. It can be thought of as a highly durable storage space in the cloud. {% include product %} uses S3 to store uploaded media and files.
 
-In order to use ShotGrid isolation features, you will bring your own S3 bucket and configure ShotGrid to use it for storage. Please refer to our [S3 Bucket Setup article](../setup/s3_bucket.md) for details on how to do this.
+In order to use {% include product %} isolation features, you will bring your own S3 bucket and configure {% include product %} to use it for storage. Please refer to our [S3 Bucket Setup article](../setup/s3_bucket.md) for details on how to do this.

--- a/docs/ja/trusted-solutions/tier1/knowledge/vpc_iam_sec.md
+++ b/docs/ja/trusted-solutions/tier1/knowledge/vpc_iam_sec.md
@@ -2,7 +2,7 @@
 layout: default
 title: VPC / IAM / Security Group
 pagename: tier1-knowledge-vpc_iam_sec
-lang: en
+lang: ja
 ---
 
 # VPC / IAM / Security Group
@@ -11,6 +11,6 @@ lang: en
 
 Within a VPC, [security groups](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html) act as a basic firewall and control what inbound and outbound connections are permitted to each given resource. For example, a security group can allow inbound **HTTPS** traffic to a proxy server but block all other inbound traffic.
 
-With [AWS Identity and Access Management (IAM)](https://aws.amazon.com/iam/), access to AWS resources and services can be controlled at a more fine-grained level. For example, IAM can be leveraged to control who or which resources can access S3 buckets used by ShotGrid.
+With [AWS Identity and Access Management (IAM)](https://aws.amazon.com/iam/), access to AWS resources and services can be controlled at a more fine-grained level. For example, IAM can be leveraged to control who or which resources can access S3 buckets used by {% include product %}.
 
-All three of the above features are used in the ShotGrid isolation features implementation to ensure that you securely connect your closed VPC to ShotGrid and allow access to the [media S3 buckets](../setup/s3_bucket.md).
+All three of the above features are used in the {% include product %} isolation features implementation to ensure that you securely connect your closed VPC to {% include product %} and allow access to the [media S3 buckets](../setup/s3_bucket.md).

--- a/docs/ja/trusted-solutions/tier1/learn/learn.md
+++ b/docs/ja/trusted-solutions/tier1/learn/learn.md
@@ -2,9 +2,9 @@
 layout: default
 title: Learn
 pagename: tier1-learn
-lang: en
+lang: ja
 ---
 
-# ShotGrid Isolation - Learn
+# {% include product %} Isolation - Learn
 
-This section will host a learning curriculum for ShotGrid Isolation features n the near future.
+This section will host a learning curriculum for {% include product %} Isolation features n the near future.

--- a/docs/ja/trusted-solutions/tier1/setup/media_segregation.md
+++ b/docs/ja/trusted-solutions/tier1/setup/media_segregation.md
@@ -2,32 +2,26 @@
 layout: default
 title: Media Traffic Isolation
 pagename: tier1-setup-media_segregation
-lang: en
+lang: ja
 ---
 
-# Media Traffic Isolation
+# Media Traffic Isolation using AWS PrivateLink for Amazon S3
 
 {% include info title="Disclaimer" content="This documentation is provided solely as an example. It explains how to set up your ShotGrid Isolation environment so that it can be connected to ShotGrid cloud infrastructure. Please adapt it to your studio security requirements as needed. As ShotGrid has no visibility on your AWS Account, ensuring that this account is secure is a client responsibility." %}
 
-The media traffic isolation feature allows your users to access media in your AWS S3 bucket privately (not transiting over the public Internet). Please note that if you have a multi-region setup and that leverages the ShotGrid Transcoding service there may still be instances where media transits across the public Internet. Reach out to our support team for more details.
+The media traffic isolation feature allows your users to access media in your AWS S3 bucket privately (not transiting over the public Internet). Please note that if you have a multi-region setup and that leverages the {% include product %} Transcoding service there may still be instances where media transits across the public Internet. Reach out to our support team for more details.
 
 Media Isolation activation is a pre-requisite to enable this feature. If you haven't done so already, see [Media Isolation](./s3_bucket.md).
 
 ## Set up a VPC in your S3 bucket AWS region
 
-{% include info title="Disclaimer" content="Before starting, decide whether your S3 proxy will be privately accessible within your VPC or publicly accessible via the Internet and choose the relevant templates in the following instructions." %}
-
-You will need to deploy a VPC with the required VPC endpoints. We provide both [private VPC](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-private-vpc.yml) and [public VPC](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-private-vpc.yml) CloudFormation templates as starting points. These template create the necessary VPCs, subnets and VPC endpoints.
+You will need to deploy a VPC with the required VPC endpoint. We provide a [private VPC](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-private-vpc-s3-privatelink.yml) CloudFormation templates as starting points. This template create the necessary VPC, subnets and VPC endpoint.
 
 * Create a [new CloudFormation stack](https://console.aws.amazon.com/cloudformation/home?#/stacks/create/template)
 * Select Template is ready
-* Set Amazon S3 URL depending upon your desired configuration
-  * Private VPC (default):
-    [`https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-private-vpc.yml`](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-private-vpc.yml)
-  * Public VPC:
-    [`https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-public-vpc.yml`](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-public-vpc.yml)
+* Set Amazon S3 URL to [`https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-private-vpc-s3-privatelink.yml`](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-private-vpc-s3-privatelink.yml)
 * Click Next
-* Set a stack name. Eg. `shotgun-vpc`
+* Set a stack name. Eg. `{% include product %}-vpc`
 * Choose network ranges that doesn't conflict with your studio network and set subnet CIDR values accordingly
 * Set your S3 bucket name
 * Click Next
@@ -43,85 +37,27 @@ Options provided by AWS:
 
 ## Add an S3 endpoint to your VPC
 
-{% include info title="Note" content="This step should only be performed if the CloudFormation template was *not* used when configuring [Media Isolation](./s3_bucket.md)." %}
+{% include info title="Note" content="This step should only be performed if the CloudFormation template was *not* used." %}
 
-![Add endpoint](../images/tier1-endpoint-create-1.png)
-![Add endpoint](../images/tier1-endpoint-create-2.png)
-![Add endpoint](../images/tier1-endpoint-create-3.png)
+Simply add an `com.amazonaws.us-west-2.s3` Interface VPC Endpoint to your existing VPC. Make sure the associated security group allow traffic from your site network.
 
-## Set up S3 proxy
+### Add the VPC to your S3 bucket policy
 
-You will need to deploy an S3 proxy in your VPC to forward traffic to the S3 VPC endpoint. We provide both [private](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy.yml) and [public](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy-public.yml) S3 proxy CloudFormation templates as starting points for this purpose. These will create the necessary Elastic Container Service (ECS) cluster and other resources to run the S3 proxy on AWS Fargate behind an AWS Application Load Balancer (ALB).
-
-### Make the Docker image available from a private AWS ECR repository
-
-* Create a [new Elastic Container Registry (ECR) repository](https://console.aws.amazon.com/ecr/create-repository)
-* Name the repository `s3-proxy`
-* Upload the s3-proxy Docker image to the newly created ECR repository
-  * [Install Docker](https://docs.docker.com/get-docker/) on your workstation
-  * Follow the `docker login` instructions shown by clicking the *View push commands* button
-  * Run the following commands, substituting the ECR endpoint in the example for yours:
-    ```
-    docker pull quay.io/shotgun/s3-proxy:1.0.6
-    docker tag quay.io/shotgun/s3-proxy:1.0.6 627791357434.dkr.ecr.us-west-2.amazonaws.com/s3-proxy:1.0.6
-    docker push 627791357434.dkr.ecr.us-west-2.amazonaws.com/s3-proxy:1.0.6
-    ```
-
-### Create S3 proxy CloudFormation stack
-
-Create a new stack in AWS Console using either the [private](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy.yml) or [public](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy-public.yml) CloudFormation template.
-
-* Create a [new CloudFormation stack](https://console.aws.amazon.com/cloudformation/home?#/stacks/create/template)
-* Select Template is ready
-* Set Amazon S3 URL depending upon your desired configuration
-  * Private S3 proxy (default):
-    [`https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy.yml`](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy.yml)
-  * Public S3 proxy:
-    [`https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy-public.yml`](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy-public.yml)
-* Click Next
-* Set a stack name up to 32 characters in length. Eg. `shotgun-s3-proxy`
-* Set the parameters that do not have default values with those used when creating the ECR repository, VPC and S3 bucket previously
-* Click Next
-* Accept `I acknowledge that AWS CloudFormation might create IAM resources`
-* Click Next
-
-### Configure HTTPS
-
-ShotGrid requires that the S3 proxy be accessed via HTTPS, therefore the AWS ALB handling requests for your newly created S3 proxy stack must be configured to accept HTTPS requests.
-
-* Create a DNS entry pointing to your S3 proxy, depending upon whether public or private
-  * Private S3 proxy (default):
-    * Go to the [EC2 Load Balancers dashboard](https://console.aws.amazon.com/ec2/home?#LoadBalancers), select your S3 proxy's ALB and make a note of the DNS name
-    * Add a DNS CNAME record pointing to the DNS name of the ALB
-      Eg. `s3-proxy.mystudio.com. 300 IN CNAME s3proxy-12R1MXX0MFFAV-2025360147.us-east-1.elb.amazonaws.com.`
-  * Public S3 proxy:
-    * Go to the [AWS Global Accelerator dashboard](https://console.aws.amazon.com/ec2/v2/home?#GlobalAcceleratorDashboard:) and make a note of the DNS name associated with your S3 proxy's accelerator
-    * Add a DNS CNAME record pointing to the DNS name of the Global Accelerator
-      Eg. `s3-proxy.mystudio.com. 300 IN CNAME a48a2a8de7cfd28d3.awsglobalaccelerator.com.`
-* Obtain an SSL certificate for your chosen URL, we recommend using [AWS Certificate Manager (ACM)](https://aws.amazon.com/certificate-manager/) for this
-* Configure HTTPS for the S3 proxy by adding a new HTTPS listener to the AWS ALB
-  * Go to the [EC2 Load Balancers dashboard](https://console.aws.amazon.com/ec2/home?#LoadBalancers), select your S3 proxy's ALB and click on the Listeners tab
-  * Click Add listener
-  * Select HTTPS from the Protocol dropdown menu
-  * Click Add action -> Forward to...
-  * Select your S3 proxy's target group from the Target group dropdown menu
-  * Select the Security policy you'd like to use. Eg. `TLS-1-2-Ext-2018-06` (See [AWS documentation](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies) for more information)
-  * Select the SSL certificate you'd like to use from ACM or import a new certificate
-  * Click Save
-
-### Add S3 proxy VPC to S3 bucket policy
-
-In order for the S3 proxy to communicate with your S3 bucket your bucket policy must allow access from the S3 proxy's VPC. You can find instructions on how to configure the policy in the [Fine Tuning](./tuning.md#s3-bucket-policy) step.
+In order for the S3 VPC endpoint to communicate with your S3 bucket your bucket policy must allow access from the S3 endpoint's VPC. You can find instructions on how to configure the policy in the [Fine Tuning](./tuning.md#s3-bucket-policy) step.
 
 ## Validation
 
-### Test the S3 proxy
+### Test the S3 VPC endpoint
 
-Try to access your S3 proxy using the ping route. Eg. `https://s3-proxy.mystudio.com/ping`
+Use the endpoint URL to list objects in your bucket using AWS CLI. In the following example, replace the VPC endpoint ID `vpce-1a2b3c4d-5e6f.s3.us-east-1.vpce.amazonaws.com` and bucket name `my-bucket` with appropriate information.
 
-### Configure your test site to use the S3 proxy
+```
+    aws s3 --endpoint-url https://bucket.vpce-1a2b3c4d-5e6f.s3.us-east-1.vpce.amazonaws.com ls s3://my-bucket/
+```
 
-* Navigate to the Site Preferences menu within ShotGrid and expand the Isolation section
+### Configure your test site to use your S3 VPC endpoint
+
+* Navigate to the Site Preferences menu within {% include product %} and expand the Isolation section
 * Set S3 Proxy Host Address to the S3 proxy url. Eg. `https://s3-proxy.mystudio.com` then click Save changes
 * Confirm that you are still able to access existing media
 * Attempt to upload new media

--- a/docs/ja/trusted-solutions/tier1/setup/media_segregation_s3_proxy.md
+++ b/docs/ja/trusted-solutions/tier1/setup/media_segregation_s3_proxy.md
@@ -1,0 +1,137 @@
+---
+layout: default
+title: Media Traffic Isolation - S3 Proxy
+pagename: tier1-setup-media_segregation_s3_proxy
+lang: ja
+---
+
+{% include info title="Deprecated" content="The preferred way is to use S3 Private Link instead of a S3 proxy, see [Media Traffic Isolation](./media_segregation.md)" %}
+
+# Media Traffic Isolation using an S3 proxy (DEPRECATED)
+
+{% include info title="Disclaimer" content="This documentation is provided solely as an example. It explains how to set up your ShotGrid Isolation environment so that it can be connected to ShotGrid cloud infrastructure. Please adapt it to your studio security requirements as needed. As ShotGrid has no visibility on your AWS Account, ensuring that this account is secure is a client responsibility." %}
+
+The media traffic isolation feature allows your users to access media in your AWS S3 bucket privately (not transiting over the public Internet). Please note that if you have a multi-region setup and that leverages the ShotGrid Transcoding service there may still be instances where media transits across the public Internet. Reach out to our support team for more details.
+
+Media Isolation activation is a pre-requisite to enable this feature. If you haven't done so already, see [Media Isolation](./s3_bucket.md).
+
+## Set up a VPC in your S3 bucket AWS region
+
+{% include info title="Disclaimer" content="Before starting, decide whether your S3 proxy will be privately accessible within your VPC or publicly accessible via the Internet and choose the relevant templates in the following instructions." %}
+
+You will need to deploy a VPC with the required VPC endpoints. We provide both [private VPC](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-private-vpc.yml) and [public VPC](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-private-vpc.yml) CloudFormation templates as starting points. These template create the necessary VPCs, subnets and VPC endpoints.
+
+* Create a [new CloudFormation stack](https://console.aws.amazon.com/cloudformation/home?#/stacks/create/template)
+* Select Template is ready
+* Set Amazon S3 URL depending upon your desired configuration
+  * Private VPC (default):
+    [`https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-private-vpc.yml`](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-private-vpc.yml)
+  * Public VPC:
+    [`https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-public-vpc.yml`](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-public-vpc.yml)
+* Click Next
+* Set a stack name. Eg. `shotgun-vpc`
+* Choose network ranges that doesn't conflict with your studio network and set subnet CIDR values accordingly
+* Set your S3 bucket name
+* Click Next
+* Click Next
+
+## Set up access from your site network to your AWS VPC
+
+Options provided by AWS:
+* [AWS Site-to-Site VPN](https://docs.aws.amazon.com/vpn/latest/s2svpn/VPC_VPN.html)
+* [AWS Direct Connect](https://aws.amazon.com/directconnect/)
+
+{% include info title="Note" content="If Direct Connect is chosen, we recommend testing with a simpler / faster solution in the meantime to validate your Isolation setup. You can then replace that solution with Direct Connect once it is available." %}
+
+## Add an S3 endpoint to your VPC
+
+{% include info title="Note" content="This step should only be performed if the CloudFormation template was *not* used when configuring [Media Isolation](./s3_bucket.md)." %}
+
+![Add endpoint](../images/tier1-endpoint-create-1.png)
+![Add endpoint](../images/tier1-endpoint-create-2.png)
+![Add endpoint](../images/tier1-endpoint-create-3.png)
+
+## Set up S3 proxy
+
+You will need to deploy an S3 proxy in your VPC to forward traffic to the S3 VPC endpoint. We provide both [private](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy.yml) and [public](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy-public.yml) S3 proxy CloudFormation templates as starting points for this purpose. These will create the necessary Elastic Container Service (ECS) cluster and other resources to run the S3 proxy on AWS Fargate behind an AWS Application Load Balancer (ALB).
+
+### Make the Docker image available from a private AWS ECR repository
+
+* Create a [new Elastic Container Registry (ECR) repository](https://console.aws.amazon.com/ecr/create-repository)
+* Name the repository `s3-proxy`
+* Upload the s3-proxy Docker image to the newly created ECR repository
+  * [Install Docker](https://docs.docker.com/get-docker/) on your workstation
+  * Follow the `docker login` instructions shown by clicking the *View push commands* button
+  * Run the following commands, substituting the ECR endpoint in the example for yours:
+    ```
+    docker pull quay.io/shotgun/s3-proxy:1.0.6
+    docker tag quay.io/shotgun/s3-proxy:1.0.6 627791357434.dkr.ecr.us-west-2.amazonaws.com/s3-proxy:1.0.6
+    docker push 627791357434.dkr.ecr.us-west-2.amazonaws.com/s3-proxy:1.0.6
+    ```
+
+### Create S3 proxy CloudFormation stack
+
+Create a new stack in AWS Console using either the [private](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy.yml) or [public](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy-public.yml) CloudFormation template.
+
+* Create a [new CloudFormation stack](https://console.aws.amazon.com/cloudformation/home?#/stacks/create/template)
+* Select Template is ready
+* Set Amazon S3 URL depending upon your desired configuration
+  * Private S3 proxy (default):
+    [`https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy.yml`](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy.yml)
+  * Public S3 proxy:
+    [`https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy-public.yml`](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy-public.yml)
+* Click Next
+* Set a stack name up to 32 characters in length. Eg. `shotgun-s3-proxy`
+* Set the parameters that do not have default values with those used when creating the ECR repository, VPC and S3 bucket previously
+* Click Next
+* Accept `I acknowledge that AWS CloudFormation might create IAM resources`
+* Click Next
+
+### Configure HTTPS
+
+ShotGrid requires that the S3 proxy be accessed via HTTPS, therefore the AWS ALB handling requests for your newly created S3 proxy stack must be configured to accept HTTPS requests.
+
+* Create a DNS entry pointing to your S3 proxy, depending upon whether public or private
+  * Private S3 proxy (default):
+    * Go to the [EC2 Load Balancers dashboard](https://console.aws.amazon.com/ec2/home?#LoadBalancers), select your S3 proxy's ALB and make a note of the DNS name
+    * Add a DNS CNAME record pointing to the DNS name of the ALB
+      Eg. `s3-proxy.mystudio.com. 300 IN CNAME s3proxy-12R1MXX0MFFAV-2025360147.us-east-1.elb.amazonaws.com.`
+  * Public S3 proxy:
+    * Go to the [AWS Global Accelerator dashboard](https://console.aws.amazon.com/ec2/v2/home?#GlobalAcceleratorDashboard:) and make a note of the DNS name associated with your S3 proxy's accelerator
+    * Add a DNS CNAME record pointing to the DNS name of the Global Accelerator
+      Eg. `s3-proxy.mystudio.com. 300 IN CNAME a48a2a8de7cfd28d3.awsglobalaccelerator.com.`
+* Obtain an SSL certificate for your chosen URL, we recommend using [AWS Certificate Manager (ACM)](https://aws.amazon.com/certificate-manager/) for this
+* Configure HTTPS for the S3 proxy by adding a new HTTPS listener to the AWS ALB
+  * Go to the [EC2 Load Balancers dashboard](https://console.aws.amazon.com/ec2/home?#LoadBalancers), select your S3 proxy's ALB and click on the Listeners tab
+  * Click Add listener
+  * Select HTTPS from the Protocol dropdown menu
+  * Click Add action -> Forward to...
+  * Select your S3 proxy's target group from the Target group dropdown menu
+  * Select the Security policy you'd like to use. Eg. `TLS-1-2-Ext-2018-06` (See [AWS documentation](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies) for more information)
+  * Select the SSL certificate you'd like to use from ACM or import a new certificate
+  * Click Save
+
+### Add S3 proxy VPC to S3 bucket policy
+
+In order for the S3 proxy to communicate with your S3 bucket your bucket policy must allow access from the S3 proxy's VPC. You can find instructions on how to configure the policy in the [Fine Tuning](./tuning.md#s3-bucket-policy) step.
+
+## Validation
+
+### Test the S3 proxy
+
+Try to access your S3 proxy using the ping route. Eg. `https://s3-proxy.mystudio.com/ping`
+
+### Configure your test site to use the S3 proxy
+
+* Navigate to the Site Preferences menu within ShotGrid and expand the Isolation section
+* Set S3 Proxy Host Address to the S3 proxy url. Eg. `https://s3-proxy.mystudio.com` then click Save changes
+* Confirm that you are still able to access existing media
+* Attempt to upload new media
+
+## Next Steps
+
+See [Web Traffic Isolation](./traffic_segregation.md) to activate the Web Traffic Isolation feature.
+
+See [Media Replication](./s3_replication.md) to activate the Web Traffic Isolation feature.
+
+Go to [Setup](./setup.md) for an overview of the possible next steps.

--- a/docs/ja/trusted-solutions/tier1/setup/migration.md
+++ b/docs/ja/trusted-solutions/tier1/setup/migration.md
@@ -2,7 +2,7 @@
 layout: default
 title: Migration
 pagename: tier1-setup-migration
-lang: en
+lang: ja
 ---
 
 # Migration
@@ -11,17 +11,17 @@ Once everything is configured and properly tested with the migration test site, 
 
 ## Test migration
 
-Ask the ShotGrid team to start the migration process in support ticket/slack.
+Ask the {% include product %} team to start the migration process in support ticket/slack.
 
-  * ShotGrid will clone your production site database to your migration test site.
-  * You will do a first sync of the media from ShotGrid's S3 bucket to your bucket. ShotGrid will provide the exact instructions.
+  * {% include product %} will clone your production site database to your migration test site.
+  * You will do a first sync of the media from {% include product %}'s S3 bucket to your bucket. {% include product %} will provide the exact instructions.
   * You can now test your site to be sure your existing media is available.
 
 ## Final migration
 
 The second test is to definitly migrate your site to use your own S3 bucket.
 
-  * You will do a second sync of the media from ShotGrid's S3 bucket to your bucket.
-  * ShotGrid will reconfigure your hosted site with media isolation. Some media will be missing until the final media sync is completed.
+  * You will do a second sync of the media from {% include product %}'s S3 bucket to your bucket.
+  * {% include product %} will reconfigure your hosted site with media isolation. Some media will be missing until the final media sync is completed.
   * You will do a final media sync.
 

--- a/docs/ja/trusted-solutions/tier1/setup/planning.md
+++ b/docs/ja/trusted-solutions/tier1/setup/planning.md
@@ -2,7 +2,7 @@
 layout: default
 title: Planning Your Setup
 pagename: tier1-getting_started-planning
-lang: en
+lang: ja
 ---
 
 # Planning Your Setup
@@ -45,7 +45,7 @@ If you plan to activate any of the Traffic Isolation feature, you will need a wa
   * AWS Direct Connect
   * Other VPN solution
 
-We highly recommand you to leverage Direct Connect. Direct Connect guarantees the lowest latency possible to the ShotGrid services, a consistent network experience, and allow you to leverage the optimization AWS is relying on to guarantee an optimal performance across the globe.
+We highly recommand you to leverage Direct Connect. Direct Connect guarantees the lowest latency possible to the {% include product %} services, a consistent network experience, and allow you to leverage the optimization AWS is relying on to guarantee an optimal performance across the globe.
 
 ## Next Step
 

--- a/docs/ja/trusted-solutions/tier1/setup/s3_bucket.md
+++ b/docs/ja/trusted-solutions/tier1/setup/s3_bucket.md
@@ -2,7 +2,7 @@
 layout: default
 title: Media Isolation
 pagename: tier1-setup-s3_bucket
-lang: en
+lang: ja
 ---
 
 # Media Isolation
@@ -24,8 +24,8 @@ It's possible to start from the [Private S3 bucket AWS CloudFormation template](
   * Select Template is ready
   * Set Amazon S3 URL to https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-private-s3-bucket.yml
   * Next
-  * Set a stack name like shotgun-s3-bucket
-  * Set your S3 bucket name and your ShotGrid site name
+  * Set a stack name like {% include product %}-s3-bucket
+  * Set your S3 bucket name and your {% include product %} site name
   * Next
   * Accept `I acknowledge that AWS CloudFormation might create IAM resources`
   * Next
@@ -38,28 +38,28 @@ CORS policy on your S3 bucket will be minimally configured, allowing only the re
 
 The template will create an AWS Role with the following permissions on your bucket:
 
-* Allow ShotGrid to access your S3 bucket.
-* Allow the ShotGrid account to assume the role by setting the role Trust Relationship.
+* Allow {% include product %} to access your S3 bucket.
+* Allow the {% include product %} account to assume the role by setting the role Trust Relationship.
 
 ## Media Isolation Activation
 
-Please contact ShotGrid support via the dedicated Slack channel and provide the following information:
+Please contact {% include product %} support via the dedicated Slack channel and provide the following information:
   * S3 bucket name
   * AWS Region
-  * ShotGrid Role ARN
+  * {% include product %} Role ARN
 
-ShotGrid will configure your test site to use your own S3 bucket.
+{% include product %} will configure your test site to use your own S3 bucket.
 
 ## Validation
 
-At this stage, you should be able to upload and download media. The ShotGrid Transcoding Service should also be able to read, transcode and write back the thumbnails, filmstrip and web friendly versions of your media back to your S3 Bucket. To validate this:
+At this stage, you should be able to upload and download media. The {% include product %} Transcoding Service should also be able to read, transcode and write back the thumbnails, filmstrip and web friendly versions of your media back to your S3 Bucket. To validate this:
 
 1. Log in your Migration Test Site.
 2. From the Navigation Bar, go the the Media app
 3. Once in the Media App, drag and drop or upload an image or a video from your computer. If you didn't created a Project yet, you may have to create one first.
 4. A version should appear, with a thumbnail, in the Media App.
 5. Validate that you can playback the media by clicking the Play button.
-6. To validate that the media has been stored in your S3 bucket, from the media viewer, click on the cog and then select or hover over view source view. The HTTPS link should contain your bucket name.
+6. To validate that the media has been stored in your S3 bucket, from the media viewer, click on the cog and then select or hover over ‘view source’. The HTTPS link should contain your bucket name.
 
 ## Next Steps
 

--- a/docs/ja/trusted-solutions/tier1/setup/s3_replication.md
+++ b/docs/ja/trusted-solutions/tier1/setup/s3_replication.md
@@ -2,14 +2,14 @@
 layout: default
 title: Media Replication
 pagename: tier1-setup-s3_replication
-lang: en
+lang: ja
 ---
 
 # Media Replication
 
 ## Description
 
-It's possible to add S3 replication between two S3 buckets in different regions and configure ShotGrid to leverage it for faster access to media.
+It's possible to add S3 replication between two S3 buckets in different regions and configure {% include product %} to leverage it for faster access to media.
 
 ![S3 Replication Diagram](../images/tier1-s3-replication.png)
 
@@ -40,10 +40,10 @@ The `IP Adresses for S3 replication` preference can be edited in Site Preference
 # Setup steps
 
   * Create the replica S3 bucket in a new AWS region. See [Media Isolation](./s3_bucket.md)
-  * Update your existing ShotGrid role policy to allow ShotGrid to also access the replica bucket
+  * Update your existing {% include product %} role policy to allow {% include product %} to also access the replica bucket
   * Setup the replication rules on the primary S3 bucket. See [How do I add a replication rule to an S3 bucket?](https://docs.aws.amazon.com/AmazonS3/latest/user-guide/enable-replication.html#enable-replication-add-rule)
   * Setup a VPC + Direct Connect + S3 proxy in the new AWS region. See [Media Traffic Isolation](./media_segregation.md)
-  * Contact ShotGrid Support to configure your site to use the new S3 replica bucket, providing the following information:
+  * Contact {% include product %} Support to configure your site to use the new S3 replica bucket, providing the following information:
     * Replica Bucket Name
     * Replica Bucket Region
     * Replica S3 proxy URL

--- a/docs/ja/trusted-solutions/tier1/setup/setup.md
+++ b/docs/ja/trusted-solutions/tier1/setup/setup.md
@@ -2,10 +2,10 @@
 layout: default
 title: Setup
 pagename: tier1-setup
-lang: en
+lang: ja
 ---
 
-# ShotGrid Isolation Feature Set - Setup
+# {% include product %} Isolation Feature Set - Setup
 
 Isolation the isolation features are independent of each other, and can be activated independently of each other. Media replication have as pre-requisite for Media Isolation to be implemented.
 
@@ -40,7 +40,7 @@ Before you start working on your setup, [put a plan in place](./planning.md). Ch
 
 ## [Migration Test Site](./shotgun_poc_site.md)
 
-To help you setting up the Isolation features without breaking your production environment and to helping smooting the migration to your isolated environment, ShotGrid propose to use a test site on which to test your setup before applying the result to production.
+To help you setting up the Isolation features without breaking your production environment and to helping smooting the migration to your isolated environment, {% include product %} propose to use a test site on which to test your setup before applying the result to production.
 
 ## [Media Isolation](./s3_bucket.md)
 

--- a/docs/ja/trusted-solutions/tier1/setup/shotgun_poc_site.md
+++ b/docs/ja/trusted-solutions/tier1/setup/shotgun_poc_site.md
@@ -2,14 +2,14 @@
 layout: default
 title: Migration Test Site
 pagename: tier1-setup-shotgun_poc_site
-lang: en
+lang: ja
 ---
 
-# ShotGrid Migration Test Site
+# {% include product %} Migration Test Site
 
 Activating the isolation feature set is an intrusive procedure that can have an impact on the usability of your site. To prevent a production stopping event, we require clients to follow an approach where the configuration is first validated on a test site, before being applied to the production site.
 
-The ShotGrid team will create a temporary site to be used as a Proof of Concept for your ShotGrid Isolation deployment. Upon the successful completion of the setup process, your existing ShotGrid site can be migrated to your ShotGrid Isolation environment.
+The {% include product %} team will create a temporary site to be used as a Proof of Concept for your {% include product %} Isolation deployment. Upon the successful completion of the setup process, your existing {% include product %} site can be migrated to your {% include product %} Isolation environment.
 
 If your Migration Test Site has not been created yet, please reach out to our Support team through your Zendesk ticket or your dedicated on-boarding Slack Channel.
 

--- a/docs/ja/trusted-solutions/tier1/setup/traffic_segregation.md
+++ b/docs/ja/trusted-solutions/tier1/setup/traffic_segregation.md
@@ -2,31 +2,31 @@
 layout: default
 title: Web Traffic Isolation
 pagename: tier1-setup-traffic_segregation
-lang: en
+lang: ja
 ---
 
 # Web Traffic Isolation
 
-The goal is to set up an AWS PrivateLink to privately access your ShotGrid site.
+The goal is to set up an AWS PrivateLink to privately access your {% include product %} site.
 
 ## Set up PrivateLink to ShotGrid
 
-  * Ask ShotGrid support to provide you with the ShotGrid PrivateLink service name for your AWS region.
+  * Ask {% include product %} support to provide you with the {% include product %} PrivateLink service name for your AWS region.
 
-  * Update the private VPC CloudFormation stack you created earlier and set ShotgunPrivateServiceName parameter.
+  * Update the private VPC CloudFormation stack you created earlier and set {% include product %}PrivateServiceName parameter.
 
 ### Manual steps if needed
 
   * Add a new VPC Endpoint in your VPC
 
-  * For the security group, ShotGrid service only requires the inbound port tcp/443 to be open.
+  * For the security group, {% include product %} service only requires the inbound port tcp/443 to be open.
 
 ![Create endpoint](../images/tier1-endpoint-create_privatelink.png)
 
 
 ## DNS Configuration
 
-Provide your PrivateLink DNS name to ShotGrid support. We will setup a new private URL for your site that will look like `mystudio-staging.priv.shotgunstudio.com`.
+Provide your PrivateLink DNS name to {% include product %} support. We will setup a new private URL for your site that will look like `mystudio-staging.priv.shotgunstudio.com`.
 
 ## Validation
 

--- a/docs/ja/trusted-solutions/tier1/setup/tuning.md
+++ b/docs/ja/trusted-solutions/tier1/setup/tuning.md
@@ -2,7 +2,7 @@
 layout: default
 title: Fine Tuning
 pagename: tier1-setup-tuning
-lang: en
+lang: ja
 ---
 
 # Fine Tuning
@@ -11,17 +11,17 @@ lang: en
 
 ### S3 Infrequent Access
 
-We recommend enabling S3 Infrequent Access to easily reduce costs without impacting performance. For the ShotGrid Cloud hosted offering, we apply a policy for all objects older than one month.
+We recommend enabling S3 Infrequent Access to easily reduce costs without impacting performance. For the {% include product %} Cloud hosted offering, we apply a policy for all objects older than one month.
 
-With Infrequent Access, objects are stored at a lower cost. However, if they are accessed, it will involve an additional cost. ShotGrid has observed that one month was the right policy to use globally, but you may want to adapt that policy to your studio workflows as needed.
+With Infrequent Access, objects are stored at a lower cost. However, if they are accessed, it will involve an additional cost. {% include product %} has observed that one month was the right policy to use globally, but you may want to adapt that policy to your studio workflows as needed.
 
 Read more about S3 Infrequent Access and other storage classes [here](https://aws.amazon.com/s3/storage-classes/).
 
 ## S3 Bucket policy
 
-We recommend you restrict access to your S3 bucket to only your VPC and ShotGrid transcoding services IPs. There is an example policy, replace `your_vpc_id` and `your_s3_bucket` by your values.
+We recommend you restrict access to your S3 bucket to only your VPC and {% include product %} transcoding services IPs. There is an example policy, replace `your_vpc_id` and `your_s3_bucket` by your values.
 
-We strongly recommend you test media access and media transcoding in your migration test site right after applying the bucket policy changes to be sure your S3 bucket is still accessible from your VPC and from ShotGrid transcoders.
+We strongly recommend you test media access and media transcoding in your migration test site right after applying the bucket policy changes to be sure your S3 bucket is still accessible from your VPC and from {% include product %} transcoders.
 
 ```
 {
@@ -59,6 +59,7 @@ We strongly recommend you test media access and media transcoding in your migrat
                 },
                 "StringNotEquals": {
                     "aws:sourceVpc": [
+                        "vpc-2fd62a56",
                         "your_vpc_id"
                     ]
                 }

--- a/docs/ko/trusted-solutions/cloud.md
+++ b/docs/ko/trusted-solutions/cloud.md
@@ -2,14 +2,14 @@
 layout: default
 title: ShotGrid in the Cloud
 pagename: cloud-index
-lang: en
+lang: ko
 ---
 
-# ShotGrid in the Cloud
+# {% include product %} in the Cloud
 
-## What is ShotGrid in the Cloud?
+## What is {% include product %} in the Cloud?
 
-ShotGrid Cloud is our default offering, hosted on AWS and built on top of Autodesk's Cloud technology platform. ShotGrid Cloud is the latest generation of our hosted service and is completely cloud based.
+{% include product %} Cloud is our default offering, hosted on AWS and built on top of Autodesk's Cloud technology platform. {% include product %} Cloud is the latest generation of our hosted service and is completely cloud based.
 
 ## Further Reading
 

--- a/docs/ko/trusted-solutions/tier1.md
+++ b/docs/ko/trusted-solutions/tier1.md
@@ -2,14 +2,14 @@
 layout: default
 title: Isolation Features
 pagename: tier1-index
-lang: en
+lang: ko
 ---
 
 # Isolation Feature Set
 
 ![isolation-theme](./tier1/images/isolation_theme.jpg)
 
-The isolation feature set is an hybrid solution that satisfies strict security and legal requirements, while minimizing ShotGrid System Admin specific required knowledge and maintenance. These features enable creative studios to confidently meet their supplier’s and studio’s highly stringent security, privacy, and performance requirements—from the cloud.
+The isolation feature set is an hybrid solution that satisfies strict security and legal requirements, while minimizing {% include product %} System Admin specific required knowledge and maintenance. These features enable creative studios to confidently meet their supplier’s and studio’s highly stringent security, privacy, and performance requirements—from the cloud.
 
 Continue to [About the isolation feature set](./tier1/getting_started/about.md) for more details.
 
@@ -46,7 +46,7 @@ Go to [Setup](./tier1/setup/setup.md) if you are ready to activate the Isolation
 ### AWS Knowledge
 <!-- When updating this, also update knowledge/knowledge.md -->
 * [Connecting Your Studio With Your AWS VPC](./tier1/knowledge/connecting.md)
-* [ShotGrid AWS Direct Connect Onboarding](./tier1/knowledge/direct_connect_onboarding.md)
+* [{% include product %} AWS Direct Connect Onboarding](./tier1/knowledge/direct_connect_onboarding.md)
 * [S3](./tier1/knowledge/s3.md)
 * [VPC / IAM / Security Group](./tier1/knowledge/vpc_iam_sec.md)
 * [Direct Connect](./tier1/knowledge/direct_connect.md)

--- a/docs/ko/trusted-solutions/tier1/features/features.md
+++ b/docs/ko/trusted-solutions/tier1/features/features.md
@@ -2,7 +2,7 @@
 layout: default
 title: Features Description
 pagename: tier1-features
-lang: en
+lang: ko
 ---
 
 # Isolation Feature Set

--- a/docs/ko/trusted-solutions/tier1/features/media_isolation.md
+++ b/docs/ko/trusted-solutions/tier1/features/media_isolation.md
@@ -2,11 +2,11 @@
 layout: default
 title: Media Isolation
 pagename: tier1-features-media-isolation
-lang: en
+lang: ko
 ---
 
 # Media Isolation
-Media Isolation allows your studio to retain ownership and control of the media and attachments that you upload to ShotGrid. With Media Isolation, all the content that you upload to ShotGrid is stored in your studio's private S3 Bucket. Access to the media is provided to the ShotGrid services only, using [AWS AssumeRole keyless Security Token Service](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html).
+Media Isolation allows your studio to retain ownership and control of the media and attachments that you upload to {% include product %}. With Media Isolation, all the content that you upload to {% include product %} is stored in your studio's private S3 Bucket. Access to the media is provided to the {% include product %} services only, using [AWS AssumeRole keyless Security Token Service](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html).
 
 <img alt="media-isolation-overview" src="../images/media-isolation-overview.png" width="400">
 
@@ -16,13 +16,13 @@ Storing media and attachments in an S3 bucket that you own means that you remain
 <img alt="media-isolation-arch" src="../images/media-isolation-arch.png" width="400">
 
 ## More about Access
-When using ShotGrid to upload and download media it is transferred directly to / from AWS S3 without transiting through Autodesk infrastructure. ShotGrid will only access media in two situations:
-1. The ShotGrid Transcoding service will get read/write access once, soon after upload, when transcoding the media. See [Ephemeral Transcoding](../getting_started/about.md#ephemeral-transcoding) for details.
-2. When the ShotGrid service generates S3 Links to your sources and transcoded media.
+When using {% include product %} to upload and download media it is transferred directly to / from AWS S3 without transiting through Autodesk infrastructure. {% include product %} will only access media in two situations:
+1. The {% include product %} Transcoding service will get read/write access once, soon after upload, when transcoding the media. See [Ephemeral Transcoding](../getting_started/about.md#ephemeral-transcoding) for details.
+2. When the {% include product %} service generates S3 Links to your sources and transcoded media.
 
-This is rendered possible by leveraging [AWS AssumeRole keyless Security Token Service](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html). When setting up Media Isolation, an AWS Role allowing ShotGrid to access your media for the action listed above is created, and the ShotGrid service is allowed to assume that role.
+This is rendered possible by leveraging [AWS AssumeRole keyless Security Token Service](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html). When setting up Media Isolation, an AWS Role allowing {% include product %} to access your media for the action listed above is created, and the {% include product %} service is allowed to assume that role.
 
-ShotGrid Support staff do not have access to your S3 Bucket under any circumstances.
+{% include product %} Support staff do not have access to your S3 Bucket under any circumstances.
 
 ## Costs
 When activating Media Isolation the following costs, previously covered by Autodesk, become the responsibility of the client:
@@ -30,4 +30,4 @@ When activating Media Isolation the following costs, previously covered by Autod
 2. **S3 Bandwidth.** Bandwidth out of the S3 bucket will be assumed by the customer.
 
 ## What Media Isolation is not providing
-Activating Media Isolation doesn't guarantee that the access to your ShotGrid site or media takes place within a closed network. 
+Activating Media Isolation doesn't guarantee that the access to your {% include product %} site or media takes place within a closed network. 

--- a/docs/ko/trusted-solutions/tier1/features/media_replication.md
+++ b/docs/ko/trusted-solutions/tier1/features/media_replication.md
@@ -2,12 +2,12 @@
 layout: default
 title: Media Replication
 pagename: tier1-features-media-replication
-lang: en
+lang: ko
 ---
 
 # Media Replication
 
-ShotGrid is compatible with the S3 Cross-Region replication feature, allowing your users located in different regions to read from the region closer to them in order to reduce latency and increase throughput. Replication to one region is currently supported.
+{% include product %} is compatible with the S3 Cross-Region replication feature, allowing your users located in different regions to read from the region closer to them in order to reduce latency and increase throughput. Replication to one region is currently supported.
 
 <img alt="media-replication-overview" src="../images/media-replication-overview.png" width="400">
 
@@ -15,23 +15,23 @@ ShotGrid is compatible with the S3 Cross-Region replication feature, allowing yo
 Media Isolation is required in order to elect Media Replication.
 
 ## Configuration by users
-When using Media Replication, each user can customize which region data is read from. A user can either specify the region to use, or use automatic mode. In automatic mode ShotGrid selects the replica determined by the user's IP address using IP ranges specified in the Isolation Preferences.
+When using Media Replication, each user can customize which region data is read from. A user can either specify the region to use, or use automatic mode. In automatic mode {% include product %} selects the replica determined by the user's IP address using IP ranges specified in the Isolation Preferences.
 
 <img alt="media-replication-preferences" src="../images/media-replication-preferences.png" width="400">
 
 ## How it works
-ShotGrid can be configured to read from up to two different buckets. Using the [AWS S3 Replication](https://docs.aws.amazon.com/AmazonS3/latest/dev/replication.html) feature, you can configure replication between buckets in different regions, and then consume media from the region closest to your users. It is important to underline that media is always uploaded to the main bucket.
+{% include product %} can be configured to read from up to two different buckets. Using the [AWS S3 Replication](https://docs.aws.amazon.com/AmazonS3/latest/dev/replication.html) feature, you can configure replication between buckets in different regions, and then consume media from the region closest to your users. It is important to underline that media is always uploaded to the main bucket.
 
 <img alt="media-replication-arch" src="../images/media-replication-arch.png" width="400">
 
 Following AWS service level agreement, S3 guarantees the replication of 99.99% of the object within 15 minutes.
 
 ### Replication Delay
-A small amount of time, typically under 15 minutes, is required before replication happens. The replication time depends on the size of the object to replicate. In order to alleviate that replication delay, ShotGrid will, for a small period of time, generate links from to object in the source bucket instead of the replica. The duration of this transitional state in configurable in the Isolation Preferences.
+A small amount of time, typically under 15 minutes, is required before replication happens. The replication time depends on the size of the object to replicate. In order to alleviate that replication delay, {% include product %} will, for a small period of time, generate links from to object in the source bucket instead of the replica. The duration of this transitional state in configurable in the Isolation Preferences.
 
 ## Costs
 Activating the Media Replication feature can increase your AWS costs considerabibly. Before activating, be aware that:
-1. Your S3 cost linked to ShotGrid usage will more or less double, because the media is now stored in two regions.
+1. Your S3 cost linked to {% include product %} usage will more or less double, because the media is now stored in two regions.
 2. You will be charged for the transfer cost between the source and the destination region. See [AWS S3 CRR and the destination region](https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-and-other-bucket-configs.html#replication-and-dest-region) for more details.
 
 ## Next Steps

--- a/docs/ko/trusted-solutions/tier1/features/media_traffic_isolation.md
+++ b/docs/ko/trusted-solutions/tier1/features/media_traffic_isolation.md
@@ -2,7 +2,7 @@
 layout: default
 title: Media Traffic Isolation
 pagename: tier1-features-media-traffic-isolation
-lang: en
+lang: ko
 ---
 
 # Media Traffic Isolation
@@ -15,7 +15,7 @@ Communication between your client systems and S3 bucket targets a number of AWS 
 An S3 Proxy component is deployed within your VPC; which is then used as the endpoint for all S3 communication. It can also be made publicly available using AWS Global Accelerator. 
 
 ## How it works
-ShotGrid can be configured to use an S3 Proxy address to communicate with your S3 bucket. Deploying the S3 Proxy component within your VPC makes it possible to isolate traffic from the public Internet completely, or to allow more tightly controlled access from the Internet to your media.
+{% include product %} can be configured to use an S3 Proxy address to communicate with your S3 bucket. Deploying the S3 Proxy component within your VPC makes it possible to isolate traffic from the public Internet completely, or to allow more tightly controlled access from the Internet to your media.
 
 <img alt="media-traffic-isolation-arch" src="../images/media-traffic-isolation-arch.png" width="400">
 

--- a/docs/ko/trusted-solutions/tier1/features/web_traffic_isolation.md
+++ b/docs/ko/trusted-solutions/tier1/features/web_traffic_isolation.md
@@ -2,12 +2,12 @@
 layout: default
 title: Web Traffic Isolation
 pagename: tier1-features-web-traffic-isolation
-lang: en
+lang: ko
 ---
 
 # Web Traffic Isolation
 
-Communication between your client systems and your ShotGrid site will traverse the open Internet by default. Web Traffic Isolation allows you to restrict access to your ShotGrid site from the public Internet entirely and ensure that all traffic transits directly between your AWS VPC and Autodesk's AWS VPC.
+Communication between your client systems and your {% include product %} site will traverse the open Internet by default. Web Traffic Isolation allows you to restrict access to your {% include product %} site from the public Internet entirely and ensure that all traffic transits directly between your AWS VPC and Autodesk's AWS VPC.
 
 <img alt="web-traffic-isolation-overview" src="../images/web-traffic-isolation-overview.png" width="400">
 

--- a/docs/ko/trusted-solutions/tier1/getting_started/about.md
+++ b/docs/ko/trusted-solutions/tier1/getting_started/about.md
@@ -2,12 +2,12 @@
 layout: default
 title: About the Isolation Feature Set
 pagename: tier1-getting_started-about
-lang: en
+lang: ko
 ---
 
 # What is the Isolation Feature Set
 
-The isolation feature set combines our Cloud Hosted Platform with client-managed AWS resources to provide a solution that satisfies the most stringent security and privacy requirements. Clients retain control of their sensitive content without having to host ShotGrid on their infrastructure.
+The isolation feature set combines our Cloud Hosted Platform with client-managed AWS resources to provide a solution that satisfies the most stringent security and privacy requirements. Clients retain control of their sensitive content without having to host {% include product %} on their infrastructure.
 
 Leveraging the isolation feature set has the following advantages over the Standard offering:
 
@@ -15,28 +15,28 @@ Leveraging the isolation feature set has the following advantages over the Stand
 * **Web Traffic Isolation** from the public internet
 * **Media Traffic Isolation** from the public internet
 * **Media Replication** allowing you to replicate media in one additional AWS Region
-* Access to fully managed ShotGrid Cloud Services
+* Access to fully managed {% include product %} Cloud Services
 * Automatic and continuous version upgrades
 * Ephemeral compute + in-memory segration between clients
 
-In a nutshell, this means that with the isolation features, your ShotGrid site and the data related to it cannot be reached by anyone outside of your studio network.
+In a nutshell, this means that with the isolation features, your {% include product %} site and the data related to it cannot be reached by anyone outside of your studio network.
 
-The isolation feature set is a solution that requires less upkeep, as well as less IT/System Administrator knowledge and skills, than hosting ShotGrid on-premise. The list of advantages compared to on-premise includes, but is not limited to:
+The isolation feature set is a solution that requires less upkeep, as well as less IT/System Administrator knowledge and skills, than hosting {% include product %} on-premise. The list of advantages compared to on-premise includes, but is not limited to:
 
-* No ShotGrid specific knowledge required
-* No manual ShotGrid updates required
+* No {% include product %} specific knowledge required
+* No manual {% include product %} updates required
 * Very low level of maintenance required for the AWS components
 
 ## Media isolation feature
-Media Isolation allows your studio to keep the ownership and control of the media and attachments that you upload to ShotGrid. With Media Isolation, all the content that you upload to ShotGrid can be store in your studio private S3 bucket. Access to the media is provided to the ShotGrid service only, using AWS AssumeRole keyless Security Token Service. Your studio remains in control of the assets and the access to the assets, access that you can revoke at will.
+Media Isolation allows your studio to keep the ownership and control of the media and attachments that you upload to {% include product %}. With Media Isolation, all the content that you upload to {% include product %} can be store in your studio private S3 bucket. Access to the media is provided to the {% include product %} service only, using AWS AssumeRole keyless Security Token Service. Your studio remains in control of the assets and the access to the assets, access that you can revoke at will.
 
 ## Traffic isolation features
-Media and Web traffic isolation features can be enabled to prevent your traffic from being routed on the public internet, limiting it to the AWS backbone and your studio network. The traffic between ShotGrid Services and your studio stays in closed network, never going outside AWS or your Studio network.
+Media and Web traffic isolation features can be enabled to prevent your traffic from being routed on the public internet, limiting it to the AWS backbone and your studio network. The traffic between {% include product %} Services and your studio stays in closed network, never going outside AWS or your Studio network.
 
 With the Media Traffic Isolation feature activated, the media will only leave your studio infrastructure once to get transcoded.
 
 ## Media Replication
-ShotGrid is compatible with the S3 Cross-Region replication feature, allowing your users located in different regions to read from the region closer to them in order to reduce latency and increase throughput. Replication to one region is currently supported.
+{% include product %} is compatible with the S3 Cross-Region replication feature, allowing your users located in different regions to read from the region closer to them in order to reduce latency and increase throughput. Replication to one region is currently supported.
 
 
 # Eligibility
@@ -46,26 +46,26 @@ The Isolation feature set is available for all Super Awesome clients. See [Getti
 
 # What the Isolation Feature Set is not
 
-The isolation feature set is not a completely isolated solution. Both the compute services and the database services are shared amongst clients, and managed by ShotGrid. From a hardware standpoint, the isolation features does not guarantee complete physical isolation. However, ShotGrid services are guaranteeing isolation at the memory level. Processes are never reused to answer requests from different clients during their lifetime. Client metadata is stored in different databases. Client media is individually stored on S3.
+The isolation feature set is not a completely isolated solution. Both the compute services and the database services are shared amongst clients, and managed by {% include product %}. From a hardware standpoint, the isolation features does not guarantee complete physical isolation. However, {% include product %} services are guaranteeing isolation at the memory level. Processes are never reused to answer requests from different clients during their lifetime. Client metadata is stored in different databases. Client media is individually stored on S3.
 
 
 # High Level Architecture
 ![tier1-arch](../images/tier1-about-arch.png)
 
-The ShotGrid cloud service  can be decoupled at a high level in 3 parts:
+The {% include product %} cloud service  can be decoupled at a high level in 3 parts:
 
-**Compute Stack:** The part of the ShotGrid Service that handles client requests and serves data to the client.
+**Compute Stack:** The part of the {% include product %} Service that handles client requests and serves data to the client.
 
 **Data Stack:** Metadata storage (databases).
 
-**Media Storage:** Where the client's attachments, media, and assets are stored. ShotGrid uses AWS S3 to store client content.
+**Media Storage:** Where the client's attachments, media, and assets are stored. {% include product %} uses AWS S3 to store client content.
 
-Please read [Securing Studio IP in AWS: Cloud-based VFX Project Management with Autodesk ShotGrid](https://aws.amazon.com/blogs/media/securing-studio-ip-in-aws-cloud-based-vfx-project-management-with-autodesk-shotgun/) for more details about the architecture.
+Please read [Securing Studio IP in AWS: Cloud-based VFX Project Management with Autodesk {% include product %}](https://aws.amazon.com/blogs/media/securing-studio-ip-in-aws-cloud-based-vfx-project-management-with-autodesk-shotgun/) for more details about the architecture.
 
 ## Ephemeral compute and memory isolation
-Even if clients share the same infrastructure, ShotGrid guarantees a complete memory isolation, both in transit and at rest, of client data. This makes ShotGrid less prone to data leaking due to architecture flaws or software vulnerabilities exploiting memory, like buffer overflow.
+Even if clients share the same infrastructure, {% include product %} guarantees a complete memory isolation, both in transit and at rest, of client data. This makes {% include product %} less prone to data leaking due to architecture flaws or software vulnerabilities exploiting memory, like buffer overflow.
 
 ## Ephemeral transcoding
 ![tier1-transcoding](../images/tier1-about-transcoding.png)
 
-Everytime media is uploaded to ShotGrid, the transcoding service is invoked to create a web friendly versions of your assets. That process happens only once, after the initial upload. The media is directly uploaded from the client to S3, from where it is fetched by the ShotGrid Transcoding Service. Each transcoding job is handled by a single container, which is killed after that unique job. The only place the media temporarily lives is in the container memory. The ShotGrid Transcoding service doesn't store permanently a copy of your media.
+Everytime media is uploaded to {% include product %}, the transcoding service is invoked to create a web friendly versions of your assets. That process happens only once, after the initial upload. The media is directly uploaded from the client to S3, from where it is fetched by the {% include product %} Transcoding Service. Each transcoding job is handled by a single container, which is killed after that unique job. The only place the media temporarily lives is in the container memory. The {% include product %} Transcoding service doesn't store permanently a copy of your media.

--- a/docs/ko/trusted-solutions/tier1/getting_started/getting_started.md
+++ b/docs/ko/trusted-solutions/tier1/getting_started/getting_started.md
@@ -2,7 +2,7 @@
 layout: default
 title: Getting Started
 pagename: tier1-getting_started
-lang: en
+lang: ko
 ---
 
 # Isolation Feature Set - Getting Started

--- a/docs/ko/trusted-solutions/tier1/getting_started/onboarding.md
+++ b/docs/ko/trusted-solutions/tier1/getting_started/onboarding.md
@@ -2,7 +2,7 @@
 layout: default
 title: Onboarding Process
 pagename: tier1-getting_started-onboarding
-lang: en
+lang: ko
 ---
 
 # Onboarding Process
@@ -11,7 +11,7 @@ Leveraging the isolation features requires adopters to become AWS users. In orde
 
 Autodesk and Amazon will provide dedicated resources during the onboarding process to help you on this journey.
 
-To start the on-boarding process for any of the Isolation features, please open a [ShotGrid Support ticket](https://support.shotgunsoftware.com/hc/en-us/requests/new), before proceeding with [your setup](../setup/setup.md)
+To start the on-boarding process for any of the Isolation features, please open a [{% include product %} Support ticket](https://support.shotgunsoftware.com/hc/en-us/requests/new), before proceeding with [your setup](../setup/setup.md)
 
 ## Onboarding Process Overview
 
@@ -23,19 +23,19 @@ During the onboarding process, you'll have direct access to Autodesk and AWS Lea
 
 **Tech Deep Dive:**  OPTIONAL. Deeper technical dive into isolation features. This meeting can be combined with the Tech Briefing.
 
-**Kickoff Meeting:**	AWS and ShotGrid Leaders review the setup process with the you.
+**Kickoff Meeting:**	AWS and {% include product %} Leaders review the setup process with the you.
 
-**Setup / Test / Validation:**	Iterative installation process where you connect your AWS resources to ShotGrid, and activate the isolation features.
+**Setup / Test / Validation:**	Iterative installation process where you connect your AWS resources to {% include product %}, and activate the isolation features.
 
-**Training:** OPTIONAL. Help sessions, if needed, as you ramp up on the AWS/ShotGrid technologies required to securely set-up the isolation features for your site.
+**Training:** OPTIONAL. Help sessions, if needed, as you ramp up on the AWS/{% include product %} technologies required to securely set-up the isolation features for your site.
 
 ## Onboarding Resources
 
-**ShotGrid Community:** The [ShotGrid Isolation Community](https://community.shotgunsoftware.com/c/trusted-solutions/isolation/34) forum can be used to ask questions that can be answered by either ShotGrid Experts or other isolation features users. This should be your first stop when asking general questions about isolation features, during setup and beyond.
+**{% include product %} Community:** The [{% include product %} Isolation Community](https://community.shotgridsoftware.com/c/trusted-solutions/isolation/34) forum can be used to ask questions that can be answered by either {% include product %} Experts or other isolation features users. This should be your first stop when asking general questions about isolation features, during setup and beyond.
 
-**Private Slack Channel:** During the onboarding, you will be given access to a dedicated Autodesk Slack Channel. Your ShotGrid and AWS Leaders will be available for quick feedback, answers, and ad-hoc meetings to help you progress as fast as possible with your ShotGrid Isolation setup. This channel will be available only for the onboarding period.
+**Private Slack Channel:** During the onboarding, you will be given access to a dedicated Autodesk Slack Channel. Your {% include product %} and AWS Leaders will be available for quick feedback, answers, and ad-hoc meetings to help you progress as fast as possible with your {% include product %} Isolation setup. This channel will be available only for the onboarding period.
 
-**ShotGrid Support:** A [ShotGrid Support](https://support.shotgunsoftware.com/hc/en-us/requests/new) ticket will be used to track your onboarding at a higher level. Once your ShotGrid Isolation setup is complete, follow-up support tickets can be opened with the support team as needed.
+**{% include product %} Support:** A [{% include product %} Support](https://support.shotgunsoftware.com/hc/en-us/requests/new) ticket will be used to track your onboarding at a higher level. Once your {% include product %} Isolation setup is complete, follow-up support tickets can be opened with the support team as needed.
 
 ## Next Steps
 

--- a/docs/ko/trusted-solutions/tier1/getting_started/responsibilities.md
+++ b/docs/ko/trusted-solutions/tier1/getting_started/responsibilities.md
@@ -2,7 +2,7 @@
 layout: default
 title: Client Responsibilities
 pagename: tier1-getting_started-responsibilities
-lang: en
+lang: ko
 ---
   
 # Client Responsibilities
@@ -15,7 +15,7 @@ You are entirely responsible for the validity, security, and execution of the Is
  
 Autodesk is available during the process for assistance, but the configuration of Isolation features in Your AWS Account is to be executed by You on Your own.
 
-Isolation feature set activation requires the ShotGrid Support team's intervention. Activation delays are to be expected and will depend on demand. You understand that an estimated period of 2-8 weeks is usually required to complete the setup necessary to implement the isolation feature set. The setup time is highly dependent on your cooperation, so please plan to dedicate resources for the setup before beginning the onboarding process.
+Isolation feature set activation requires the {% include product %} Support team's intervention. Activation delays are to be expected and will depend on demand. You understand that an estimated period of 2-8 weeks is usually required to complete the setup necessary to implement the isolation feature set. The setup time is highly dependent on your cooperation, so please plan to dedicate resources for the setup before beginning the onboarding process.
 
 Autodesk does not guarantee any timeline for setup completion.
 
@@ -24,13 +24,13 @@ Autodesk does not guarantee any timeline for setup completion.
 |Type|	Description / Agreement |	Responsibility	| Available for Assistance|
 |--------|-----|----------|---------|
 |AWS Knowledge	|	Acquiring the AWS-specific knowledge required to set up the isolation features.	|You	|N/A|
-|S3|Setting up the S3 Bucket that will host Your media Securing access to the S3 Bucket. Additional high-availability measures (versioning, bucket replication, etc.)	|You	|ShotGrid and *AWS|
+|S3|Setting up the S3 Bucket that will host Your media Securing access to the S3 Bucket. Additional high-availability measures (versioning, bucket replication, etc.)	|You	|{% include product %} and *AWS|
 |Closed VPC	|Setting up DirectConnect/VPN, etc. to allow closed access to the VPC. Securing the VPC by putting the correct Security Groups in place.	|You	|*AWS |
-|Media Isolation	|Creating the S3 end-points. Deploying the S3 Proxy.	|You|	ShotGrid and *AWS |
-|Traffic Isolation	|Creating VPCs. Creating Subnets.|	You|ShotGrid|
-|Private Access Point|Checking that the access point is only available from Your network.|	ShotGrid|	N/A|
-|Monitoring and Reliability|Maintaining uptime up to Autodesk standards. High availability and redundancy of Cloud Services. Metadata and database resiliency and redundancy. Maintaining Recovery Point Objective (RPO) for metadata and database.	|ShotGrid|N/A|
-|Service Level Objective|Maintaining ShotGrid target RPO and RTO (See [ShotGrid Security White Paper](https://support.shotgunsoftware.com/hc/en-us/articles/114094526153-Shotgun-security-white-paper) for more details).|ShotGrid|	N/A|
-|Security and Governance |Maintaining the ShotGrid Cloud Services that Isolation clients are interfacing with, so that they are meeting expectations in terms of security, vulnerability patching, scanning, auditing, etc. (See [ShotGrid Security White Paper](https://support.shotgunsoftware.com/hc/en-us/articles/114094526153-Shotgun-security-white-paper) for more details).|	ShotGrid	|N/A|
+|Media Isolation	|Creating the S3 end-points. Deploying the S3 Proxy.	|You|	{% include product %} and *AWS |
+|Traffic Isolation	|Creating VPCs. Creating Subnets.|	You|{% include product %}|
+|Private Access Point|Checking that the access point is only available from Your network.|	{% include product %}|	N/A|
+|Monitoring and Reliability|Maintaining uptime up to Autodesk standards. High availability and redundancy of Cloud Services. Metadata and database resiliency and redundancy. Maintaining Recovery Point Objective (RPO) for metadata and database.	|{% include product %}|N/A|
+|Service Level Objective|Maintaining {% include product %} target RPO and RTO (See [{% include product %} Security White Paper](https://support.shotgunsoftware.com/hc/en-us/articles/114094526153-Shotgun-security-white-paper) for more details).|{% include product %}|	N/A|
+|Security and Governance |Maintaining the {% include product %} Cloud Services that Isolation clients are interfacing with, so that they are meeting expectations in terms of security, vulnerability patching, scanning, auditing, etc. (See [{% include product %} Security White Paper](https://support.shotgunsoftware.com/hc/en-us/articles/114094526153-Shotgun-security-white-paper) for more details).|	{% include product %}	|N/A|
 
 *You are solely responsible to seek or obtain any support services AWS may provide under any existing relationship between You and AWS. Autodesk teams are not parties to Your relationship with AWS and therefore not responsible or liable for any services or lack thereof provided by AWS to You. 

--- a/docs/ko/trusted-solutions/tier1/knowledge/aws.md
+++ b/docs/ko/trusted-solutions/tier1/knowledge/aws.md
@@ -2,7 +2,7 @@
 layout: default
 title: AWS Knowledge
 pagename: tier1-knowledge-aws
-lang: en
+lang: ko
 ---
 
 # AWS Knowledge

--- a/docs/ko/trusted-solutions/tier1/knowledge/connecting.md
+++ b/docs/ko/trusted-solutions/tier1/knowledge/connecting.md
@@ -2,7 +2,7 @@
 layout: default
 title: Connecting Your Studio With Your AWS VPC
 pagename: tier1-knowledge-connecting
-lang: en
+lang: ko
 ---
 
 # Connecting Your Studio With Your AWS VPC

--- a/docs/ko/trusted-solutions/tier1/knowledge/direct_connect.md
+++ b/docs/ko/trusted-solutions/tier1/knowledge/direct_connect.md
@@ -2,7 +2,7 @@
 layout: default
 title: Direct Connect
 pagename: tier1-knowledge-direct_connect
-lang: en
+lang: ko
 ---
 
 # Direct Connect

--- a/docs/ko/trusted-solutions/tier1/knowledge/direct_connect_onboarding.md
+++ b/docs/ko/trusted-solutions/tier1/knowledge/direct_connect_onboarding.md
@@ -2,9 +2,10 @@
 layout: default
 title: ShotGrid AWS Direct Connect Onboarding
 pagename: tier1-knowledge-direct_connect_onboarding
+lang: ko
 ---
 
-# ShotGrid AWS Direct Connect Onboarding
+# {% include product %} AWS Direct Connect Onboarding
 
 
 ## Introduction
@@ -40,7 +41,7 @@ If you answer “yes” to the following, then request a dedicated Direct Connec
 
 If you answer “yes” to the following, then request a dedicated Direct Connect connection through the AWS Console and select a Partner to assist (Option 1b):
 
-- Are you planning to use AWS Direct Connect to connect to other AWS resources outside of ShotGrid?
+- Are you planning to use AWS Direct Connect to connect to other AWS resources outside of {% include product %}?
 - Do you have the time and resources to complete the setup?
 - Are you looking for any one of the following - 1Gbps, 10Gbps port, or a dedicated connection?
 

--- a/docs/ko/trusted-solutions/tier1/knowledge/endpoints.md
+++ b/docs/ko/trusted-solutions/tier1/knowledge/endpoints.md
@@ -2,7 +2,7 @@
 layout: default
 title: VPC Endpoints
 pagename: tier1-knowledge-endpoints
-lang: en
+lang: ko
 ---
 
 # VPC Endpoints

--- a/docs/ko/trusted-solutions/tier1/knowledge/knowledge.md
+++ b/docs/ko/trusted-solutions/tier1/knowledge/knowledge.md
@@ -2,7 +2,7 @@
 layout: default
 title: Knowledge
 pagename: tier1-knowledge
-lang: en
+lang: ko
 ---
 
 # Generic Knowledge
@@ -10,7 +10,7 @@ lang: en
 ## In This Section
 <!-- When updating this, also update tier1.md -->
 * [Connecting Your Studio With Your AWS VPC](./connecting.md)
-* [ShotGrid AWS Direct Connect Onboarding](./direct_connect_onboarding.md)
+* [{% include product %} AWS Direct Connect Onboarding](./direct_connect_onboarding.md)
 * [S3](./s3.md)
 * [VPC / IAM / Security Group](./vpc_iam_sec.md)
 * [Direct Connect](./direct_connect.md)

--- a/docs/ko/trusted-solutions/tier1/knowledge/private_link.md
+++ b/docs/ko/trusted-solutions/tier1/knowledge/private_link.md
@@ -2,11 +2,11 @@
 layout: default
 title: Private Link
 pagename: tier1-knowledge-private_link
-lang: en
+lang: ko
 ---
 
 # Private Link
 
 [AWS PrivateLink](https://aws.amazon.com/privatelink/) is an AWS service that connects different AWS VPCs without going through the public internet. 
 
-In conjunction with [AWS Direct Connect](./direct_connect.md), PrivateLink helps create a dedicated connection between your studio and ShotGrid's infrastructure.
+In conjunction with [AWS Direct Connect](./direct_connect.md), PrivateLink helps create a dedicated connection between your studio and {% include product %}'s infrastructure.

--- a/docs/ko/trusted-solutions/tier1/knowledge/s3.md
+++ b/docs/ko/trusted-solutions/tier1/knowledge/s3.md
@@ -2,11 +2,11 @@
 layout: default
 title: S3
 pagename: tier1-knowledge-s3
-lang: en
+lang: ko
 ---
 
 # S3
 
-[Amazon S3](https://aws.amazon.com/s3/) is an object storage service offered by AWS. It can be thought of as a highly durable storage space in the cloud. ShotGrid uses S3 to store uploaded media and files.
+[Amazon S3](https://aws.amazon.com/s3/) is an object storage service offered by AWS. It can be thought of as a highly durable storage space in the cloud. {% include product %} uses S3 to store uploaded media and files.
 
-In order to use ShotGrid isolation features, you will bring your own S3 bucket and configure ShotGrid to use it for storage. Please refer to our [S3 Bucket Setup article](../setup/s3_bucket.md) for details on how to do this.
+In order to use {% include product %} isolation features, you will bring your own S3 bucket and configure {% include product %} to use it for storage. Please refer to our [S3 Bucket Setup article](../setup/s3_bucket.md) for details on how to do this.

--- a/docs/ko/trusted-solutions/tier1/knowledge/vpc_iam_sec.md
+++ b/docs/ko/trusted-solutions/tier1/knowledge/vpc_iam_sec.md
@@ -2,7 +2,7 @@
 layout: default
 title: VPC / IAM / Security Group
 pagename: tier1-knowledge-vpc_iam_sec
-lang: en
+lang: ko
 ---
 
 # VPC / IAM / Security Group
@@ -11,6 +11,6 @@ lang: en
 
 Within a VPC, [security groups](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html) act as a basic firewall and control what inbound and outbound connections are permitted to each given resource. For example, a security group can allow inbound **HTTPS** traffic to a proxy server but block all other inbound traffic.
 
-With [AWS Identity and Access Management (IAM)](https://aws.amazon.com/iam/), access to AWS resources and services can be controlled at a more fine-grained level. For example, IAM can be leveraged to control who or which resources can access S3 buckets used by ShotGrid.
+With [AWS Identity and Access Management (IAM)](https://aws.amazon.com/iam/), access to AWS resources and services can be controlled at a more fine-grained level. For example, IAM can be leveraged to control who or which resources can access S3 buckets used by {% include product %}.
 
-All three of the above features are used in the ShotGrid isolation features implementation to ensure that you securely connect your closed VPC to ShotGrid and allow access to the [media S3 buckets](../setup/s3_bucket.md).
+All three of the above features are used in the {% include product %} isolation features implementation to ensure that you securely connect your closed VPC to {% include product %} and allow access to the [media S3 buckets](../setup/s3_bucket.md).

--- a/docs/ko/trusted-solutions/tier1/learn/learn.md
+++ b/docs/ko/trusted-solutions/tier1/learn/learn.md
@@ -2,9 +2,9 @@
 layout: default
 title: Learn
 pagename: tier1-learn
-lang: en
+lang: ko
 ---
 
-# ShotGrid Isolation - Learn
+# {% include product %} Isolation - Learn
 
-This section will host a learning curriculum for ShotGrid Isolation features n the near future.
+This section will host a learning curriculum for {% include product %} Isolation features n the near future.

--- a/docs/ko/trusted-solutions/tier1/setup/media_segregation.md
+++ b/docs/ko/trusted-solutions/tier1/setup/media_segregation.md
@@ -2,32 +2,26 @@
 layout: default
 title: Media Traffic Isolation
 pagename: tier1-setup-media_segregation
-lang: en
+lang: ko
 ---
 
-# Media Traffic Isolation
+# Media Traffic Isolation using AWS PrivateLink for Amazon S3
 
 {% include info title="Disclaimer" content="This documentation is provided solely as an example. It explains how to set up your ShotGrid Isolation environment so that it can be connected to ShotGrid cloud infrastructure. Please adapt it to your studio security requirements as needed. As ShotGrid has no visibility on your AWS Account, ensuring that this account is secure is a client responsibility." %}
 
-The media traffic isolation feature allows your users to access media in your AWS S3 bucket privately (not transiting over the public Internet). Please note that if you have a multi-region setup and that leverages the ShotGrid Transcoding service there may still be instances where media transits across the public Internet. Reach out to our support team for more details.
+The media traffic isolation feature allows your users to access media in your AWS S3 bucket privately (not transiting over the public Internet). Please note that if you have a multi-region setup and that leverages the {% include product %} Transcoding service there may still be instances where media transits across the public Internet. Reach out to our support team for more details.
 
 Media Isolation activation is a pre-requisite to enable this feature. If you haven't done so already, see [Media Isolation](./s3_bucket.md).
 
 ## Set up a VPC in your S3 bucket AWS region
 
-{% include info title="Disclaimer" content="Before starting, decide whether your S3 proxy will be privately accessible within your VPC or publicly accessible via the Internet and choose the relevant templates in the following instructions." %}
-
-You will need to deploy a VPC with the required VPC endpoints. We provide both [private VPC](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-private-vpc.yml) and [public VPC](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-private-vpc.yml) CloudFormation templates as starting points. These template create the necessary VPCs, subnets and VPC endpoints.
+You will need to deploy a VPC with the required VPC endpoint. We provide a [private VPC](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-private-vpc-s3-privatelink.yml) CloudFormation templates as starting points. This template create the necessary VPC, subnets and VPC endpoint.
 
 * Create a [new CloudFormation stack](https://console.aws.amazon.com/cloudformation/home?#/stacks/create/template)
 * Select Template is ready
-* Set Amazon S3 URL depending upon your desired configuration
-  * Private VPC (default):
-    [`https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-private-vpc.yml`](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-private-vpc.yml)
-  * Public VPC:
-    [`https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-public-vpc.yml`](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-public-vpc.yml)
+* Set Amazon S3 URL to [`https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-private-vpc-s3-privatelink.yml`](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-private-vpc-s3-privatelink.yml)
 * Click Next
-* Set a stack name. Eg. `shotgun-vpc`
+* Set a stack name. Eg. `{% include product %}-vpc`
 * Choose network ranges that doesn't conflict with your studio network and set subnet CIDR values accordingly
 * Set your S3 bucket name
 * Click Next
@@ -43,85 +37,27 @@ Options provided by AWS:
 
 ## Add an S3 endpoint to your VPC
 
-{% include info title="Note" content="This step should only be performed if the CloudFormation template was *not* used when configuring [Media Isolation](./s3_bucket.md)." %}
+{% include info title="Note" content="This step should only be performed if the CloudFormation template was *not* used." %}
 
-![Add endpoint](../images/tier1-endpoint-create-1.png)
-![Add endpoint](../images/tier1-endpoint-create-2.png)
-![Add endpoint](../images/tier1-endpoint-create-3.png)
+Simply add an `com.amazonaws.us-west-2.s3` Interface VPC Endpoint to your existing VPC. Make sure the associated security group allow traffic from your site network.
 
-## Set up S3 proxy
+### Add the VPC to your S3 bucket policy
 
-You will need to deploy an S3 proxy in your VPC to forward traffic to the S3 VPC endpoint. We provide both [private](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy.yml) and [public](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy-public.yml) S3 proxy CloudFormation templates as starting points for this purpose. These will create the necessary Elastic Container Service (ECS) cluster and other resources to run the S3 proxy on AWS Fargate behind an AWS Application Load Balancer (ALB).
-
-### Make the Docker image available from a private AWS ECR repository
-
-* Create a [new Elastic Container Registry (ECR) repository](https://console.aws.amazon.com/ecr/create-repository)
-* Name the repository `s3-proxy`
-* Upload the s3-proxy Docker image to the newly created ECR repository
-  * [Install Docker](https://docs.docker.com/get-docker/) on your workstation
-  * Follow the `docker login` instructions shown by clicking the *View push commands* button
-  * Run the following commands, substituting the ECR endpoint in the example for yours:
-    ```
-    docker pull quay.io/shotgun/s3-proxy:1.0.6
-    docker tag quay.io/shotgun/s3-proxy:1.0.6 627791357434.dkr.ecr.us-west-2.amazonaws.com/s3-proxy:1.0.6
-    docker push 627791357434.dkr.ecr.us-west-2.amazonaws.com/s3-proxy:1.0.6
-    ```
-
-### Create S3 proxy CloudFormation stack
-
-Create a new stack in AWS Console using either the [private](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy.yml) or [public](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy-public.yml) CloudFormation template.
-
-* Create a [new CloudFormation stack](https://console.aws.amazon.com/cloudformation/home?#/stacks/create/template)
-* Select Template is ready
-* Set Amazon S3 URL depending upon your desired configuration
-  * Private S3 proxy (default):
-    [`https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy.yml`](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy.yml)
-  * Public S3 proxy:
-    [`https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy-public.yml`](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy-public.yml)
-* Click Next
-* Set a stack name up to 32 characters in length. Eg. `shotgun-s3-proxy`
-* Set the parameters that do not have default values with those used when creating the ECR repository, VPC and S3 bucket previously
-* Click Next
-* Accept `I acknowledge that AWS CloudFormation might create IAM resources`
-* Click Next
-
-### Configure HTTPS
-
-ShotGrid requires that the S3 proxy be accessed via HTTPS, therefore the AWS ALB handling requests for your newly created S3 proxy stack must be configured to accept HTTPS requests.
-
-* Create a DNS entry pointing to your S3 proxy, depending upon whether public or private
-  * Private S3 proxy (default):
-    * Go to the [EC2 Load Balancers dashboard](https://console.aws.amazon.com/ec2/home?#LoadBalancers), select your S3 proxy's ALB and make a note of the DNS name
-    * Add a DNS CNAME record pointing to the DNS name of the ALB
-      Eg. `s3-proxy.mystudio.com. 300 IN CNAME s3proxy-12R1MXX0MFFAV-2025360147.us-east-1.elb.amazonaws.com.`
-  * Public S3 proxy:
-    * Go to the [AWS Global Accelerator dashboard](https://console.aws.amazon.com/ec2/v2/home?#GlobalAcceleratorDashboard:) and make a note of the DNS name associated with your S3 proxy's accelerator
-    * Add a DNS CNAME record pointing to the DNS name of the Global Accelerator
-      Eg. `s3-proxy.mystudio.com. 300 IN CNAME a48a2a8de7cfd28d3.awsglobalaccelerator.com.`
-* Obtain an SSL certificate for your chosen URL, we recommend using [AWS Certificate Manager (ACM)](https://aws.amazon.com/certificate-manager/) for this
-* Configure HTTPS for the S3 proxy by adding a new HTTPS listener to the AWS ALB
-  * Go to the [EC2 Load Balancers dashboard](https://console.aws.amazon.com/ec2/home?#LoadBalancers), select your S3 proxy's ALB and click on the Listeners tab
-  * Click Add listener
-  * Select HTTPS from the Protocol dropdown menu
-  * Click Add action -> Forward to...
-  * Select your S3 proxy's target group from the Target group dropdown menu
-  * Select the Security policy you'd like to use. Eg. `TLS-1-2-Ext-2018-06` (See [AWS documentation](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies) for more information)
-  * Select the SSL certificate you'd like to use from ACM or import a new certificate
-  * Click Save
-
-### Add S3 proxy VPC to S3 bucket policy
-
-In order for the S3 proxy to communicate with your S3 bucket your bucket policy must allow access from the S3 proxy's VPC. You can find instructions on how to configure the policy in the [Fine Tuning](./tuning.md#s3-bucket-policy) step.
+In order for the S3 VPC endpoint to communicate with your S3 bucket your bucket policy must allow access from the S3 endpoint's VPC. You can find instructions on how to configure the policy in the [Fine Tuning](./tuning.md#s3-bucket-policy) step.
 
 ## Validation
 
-### Test the S3 proxy
+### Test the S3 VPC endpoint
 
-Try to access your S3 proxy using the ping route. Eg. `https://s3-proxy.mystudio.com/ping`
+Use the endpoint URL to list objects in your bucket using AWS CLI. In the following example, replace the VPC endpoint ID `vpce-1a2b3c4d-5e6f.s3.us-east-1.vpce.amazonaws.com` and bucket name `my-bucket` with appropriate information.
 
-### Configure your test site to use the S3 proxy
+```
+    aws s3 --endpoint-url https://bucket.vpce-1a2b3c4d-5e6f.s3.us-east-1.vpce.amazonaws.com ls s3://my-bucket/
+```
 
-* Navigate to the Site Preferences menu within ShotGrid and expand the Isolation section
+### Configure your test site to use your S3 VPC endpoint
+
+* Navigate to the Site Preferences menu within {% include product %} and expand the Isolation section
 * Set S3 Proxy Host Address to the S3 proxy url. Eg. `https://s3-proxy.mystudio.com` then click Save changes
 * Confirm that you are still able to access existing media
 * Attempt to upload new media

--- a/docs/ko/trusted-solutions/tier1/setup/media_segregation_s3_proxy.md
+++ b/docs/ko/trusted-solutions/tier1/setup/media_segregation_s3_proxy.md
@@ -1,0 +1,137 @@
+---
+layout: default
+title: Media Traffic Isolation - S3 Proxy
+pagename: tier1-setup-media_segregation_s3_proxy
+lang: ko
+---
+
+{% include info title="Deprecated" content="The preferred way is to use S3 Private Link instead of a S3 proxy, see [Media Traffic Isolation](./media_segregation.md)" %}
+
+# Media Traffic Isolation using an S3 proxy (DEPRECATED)
+
+{% include info title="Disclaimer" content="This documentation is provided solely as an example. It explains how to set up your ShotGrid Isolation environment so that it can be connected to ShotGrid cloud infrastructure. Please adapt it to your studio security requirements as needed. As ShotGrid has no visibility on your AWS Account, ensuring that this account is secure is a client responsibility." %}
+
+The media traffic isolation feature allows your users to access media in your AWS S3 bucket privately (not transiting over the public Internet). Please note that if you have a multi-region setup and that leverages the ShotGrid Transcoding service there may still be instances where media transits across the public Internet. Reach out to our support team for more details.
+
+Media Isolation activation is a pre-requisite to enable this feature. If you haven't done so already, see [Media Isolation](./s3_bucket.md).
+
+## Set up a VPC in your S3 bucket AWS region
+
+{% include info title="Disclaimer" content="Before starting, decide whether your S3 proxy will be privately accessible within your VPC or publicly accessible via the Internet and choose the relevant templates in the following instructions." %}
+
+You will need to deploy a VPC with the required VPC endpoints. We provide both [private VPC](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-private-vpc.yml) and [public VPC](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-private-vpc.yml) CloudFormation templates as starting points. These template create the necessary VPCs, subnets and VPC endpoints.
+
+* Create a [new CloudFormation stack](https://console.aws.amazon.com/cloudformation/home?#/stacks/create/template)
+* Select Template is ready
+* Set Amazon S3 URL depending upon your desired configuration
+  * Private VPC (default):
+    [`https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-private-vpc.yml`](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-private-vpc.yml)
+  * Public VPC:
+    [`https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-public-vpc.yml`](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-public-vpc.yml)
+* Click Next
+* Set a stack name. Eg. `shotgun-vpc`
+* Choose network ranges that doesn't conflict with your studio network and set subnet CIDR values accordingly
+* Set your S3 bucket name
+* Click Next
+* Click Next
+
+## Set up access from your site network to your AWS VPC
+
+Options provided by AWS:
+* [AWS Site-to-Site VPN](https://docs.aws.amazon.com/vpn/latest/s2svpn/VPC_VPN.html)
+* [AWS Direct Connect](https://aws.amazon.com/directconnect/)
+
+{% include info title="Note" content="If Direct Connect is chosen, we recommend testing with a simpler / faster solution in the meantime to validate your Isolation setup. You can then replace that solution with Direct Connect once it is available." %}
+
+## Add an S3 endpoint to your VPC
+
+{% include info title="Note" content="This step should only be performed if the CloudFormation template was *not* used when configuring [Media Isolation](./s3_bucket.md)." %}
+
+![Add endpoint](../images/tier1-endpoint-create-1.png)
+![Add endpoint](../images/tier1-endpoint-create-2.png)
+![Add endpoint](../images/tier1-endpoint-create-3.png)
+
+## Set up S3 proxy
+
+You will need to deploy an S3 proxy in your VPC to forward traffic to the S3 VPC endpoint. We provide both [private](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy.yml) and [public](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy-public.yml) S3 proxy CloudFormation templates as starting points for this purpose. These will create the necessary Elastic Container Service (ECS) cluster and other resources to run the S3 proxy on AWS Fargate behind an AWS Application Load Balancer (ALB).
+
+### Make the Docker image available from a private AWS ECR repository
+
+* Create a [new Elastic Container Registry (ECR) repository](https://console.aws.amazon.com/ecr/create-repository)
+* Name the repository `s3-proxy`
+* Upload the s3-proxy Docker image to the newly created ECR repository
+  * [Install Docker](https://docs.docker.com/get-docker/) on your workstation
+  * Follow the `docker login` instructions shown by clicking the *View push commands* button
+  * Run the following commands, substituting the ECR endpoint in the example for yours:
+    ```
+    docker pull quay.io/shotgun/s3-proxy:1.0.6
+    docker tag quay.io/shotgun/s3-proxy:1.0.6 627791357434.dkr.ecr.us-west-2.amazonaws.com/s3-proxy:1.0.6
+    docker push 627791357434.dkr.ecr.us-west-2.amazonaws.com/s3-proxy:1.0.6
+    ```
+
+### Create S3 proxy CloudFormation stack
+
+Create a new stack in AWS Console using either the [private](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy.yml) or [public](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy-public.yml) CloudFormation template.
+
+* Create a [new CloudFormation stack](https://console.aws.amazon.com/cloudformation/home?#/stacks/create/template)
+* Select Template is ready
+* Set Amazon S3 URL depending upon your desired configuration
+  * Private S3 proxy (default):
+    [`https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy.yml`](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy.yml)
+  * Public S3 proxy:
+    [`https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy-public.yml`](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy-public.yml)
+* Click Next
+* Set a stack name up to 32 characters in length. Eg. `shotgun-s3-proxy`
+* Set the parameters that do not have default values with those used when creating the ECR repository, VPC and S3 bucket previously
+* Click Next
+* Accept `I acknowledge that AWS CloudFormation might create IAM resources`
+* Click Next
+
+### Configure HTTPS
+
+ShotGrid requires that the S3 proxy be accessed via HTTPS, therefore the AWS ALB handling requests for your newly created S3 proxy stack must be configured to accept HTTPS requests.
+
+* Create a DNS entry pointing to your S3 proxy, depending upon whether public or private
+  * Private S3 proxy (default):
+    * Go to the [EC2 Load Balancers dashboard](https://console.aws.amazon.com/ec2/home?#LoadBalancers), select your S3 proxy's ALB and make a note of the DNS name
+    * Add a DNS CNAME record pointing to the DNS name of the ALB
+      Eg. `s3-proxy.mystudio.com. 300 IN CNAME s3proxy-12R1MXX0MFFAV-2025360147.us-east-1.elb.amazonaws.com.`
+  * Public S3 proxy:
+    * Go to the [AWS Global Accelerator dashboard](https://console.aws.amazon.com/ec2/v2/home?#GlobalAcceleratorDashboard:) and make a note of the DNS name associated with your S3 proxy's accelerator
+    * Add a DNS CNAME record pointing to the DNS name of the Global Accelerator
+      Eg. `s3-proxy.mystudio.com. 300 IN CNAME a48a2a8de7cfd28d3.awsglobalaccelerator.com.`
+* Obtain an SSL certificate for your chosen URL, we recommend using [AWS Certificate Manager (ACM)](https://aws.amazon.com/certificate-manager/) for this
+* Configure HTTPS for the S3 proxy by adding a new HTTPS listener to the AWS ALB
+  * Go to the [EC2 Load Balancers dashboard](https://console.aws.amazon.com/ec2/home?#LoadBalancers), select your S3 proxy's ALB and click on the Listeners tab
+  * Click Add listener
+  * Select HTTPS from the Protocol dropdown menu
+  * Click Add action -> Forward to...
+  * Select your S3 proxy's target group from the Target group dropdown menu
+  * Select the Security policy you'd like to use. Eg. `TLS-1-2-Ext-2018-06` (See [AWS documentation](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies) for more information)
+  * Select the SSL certificate you'd like to use from ACM or import a new certificate
+  * Click Save
+
+### Add S3 proxy VPC to S3 bucket policy
+
+In order for the S3 proxy to communicate with your S3 bucket your bucket policy must allow access from the S3 proxy's VPC. You can find instructions on how to configure the policy in the [Fine Tuning](./tuning.md#s3-bucket-policy) step.
+
+## Validation
+
+### Test the S3 proxy
+
+Try to access your S3 proxy using the ping route. Eg. `https://s3-proxy.mystudio.com/ping`
+
+### Configure your test site to use the S3 proxy
+
+* Navigate to the Site Preferences menu within ShotGrid and expand the Isolation section
+* Set S3 Proxy Host Address to the S3 proxy url. Eg. `https://s3-proxy.mystudio.com` then click Save changes
+* Confirm that you are still able to access existing media
+* Attempt to upload new media
+
+## Next Steps
+
+See [Web Traffic Isolation](./traffic_segregation.md) to activate the Web Traffic Isolation feature.
+
+See [Media Replication](./s3_replication.md) to activate the Web Traffic Isolation feature.
+
+Go to [Setup](./setup.md) for an overview of the possible next steps.

--- a/docs/ko/trusted-solutions/tier1/setup/migration.md
+++ b/docs/ko/trusted-solutions/tier1/setup/migration.md
@@ -2,7 +2,7 @@
 layout: default
 title: Migration
 pagename: tier1-setup-migration
-lang: en
+lang: ko
 ---
 
 # Migration
@@ -11,17 +11,17 @@ Once everything is configured and properly tested with the migration test site, 
 
 ## Test migration
 
-Ask the ShotGrid team to start the migration process in support ticket/slack.
+Ask the {% include product %} team to start the migration process in support ticket/slack.
 
-  * ShotGrid will clone your production site database to your migration test site.
-  * You will do a first sync of the media from ShotGrid's S3 bucket to your bucket. ShotGrid will provide the exact instructions.
+  * {% include product %} will clone your production site database to your migration test site.
+  * You will do a first sync of the media from {% include product %}'s S3 bucket to your bucket. {% include product %} will provide the exact instructions.
   * You can now test your site to be sure your existing media is available.
 
 ## Final migration
 
 The second test is to definitly migrate your site to use your own S3 bucket.
 
-  * You will do a second sync of the media from ShotGrid's S3 bucket to your bucket.
-  * ShotGrid will reconfigure your hosted site with media isolation. Some media will be missing until the final media sync is completed.
+  * You will do a second sync of the media from {% include product %}'s S3 bucket to your bucket.
+  * {% include product %} will reconfigure your hosted site with media isolation. Some media will be missing until the final media sync is completed.
   * You will do a final media sync.
 

--- a/docs/ko/trusted-solutions/tier1/setup/planning.md
+++ b/docs/ko/trusted-solutions/tier1/setup/planning.md
@@ -2,7 +2,7 @@
 layout: default
 title: Planning Your Setup
 pagename: tier1-getting_started-planning
-lang: en
+lang: ko
 ---
 
 # Planning Your Setup
@@ -45,7 +45,7 @@ If you plan to activate any of the Traffic Isolation feature, you will need a wa
   * AWS Direct Connect
   * Other VPN solution
 
-We highly recommand you to leverage Direct Connect. Direct Connect guarantees the lowest latency possible to the ShotGrid services, a consistent network experience, and allow you to leverage the optimization AWS is relying on to guarantee an optimal performance across the globe.
+We highly recommand you to leverage Direct Connect. Direct Connect guarantees the lowest latency possible to the {% include product %} services, a consistent network experience, and allow you to leverage the optimization AWS is relying on to guarantee an optimal performance across the globe.
 
 ## Next Step
 

--- a/docs/ko/trusted-solutions/tier1/setup/s3_bucket.md
+++ b/docs/ko/trusted-solutions/tier1/setup/s3_bucket.md
@@ -2,7 +2,7 @@
 layout: default
 title: Media Isolation
 pagename: tier1-setup-s3_bucket
-lang: en
+lang: ko
 ---
 
 # Media Isolation
@@ -24,8 +24,8 @@ It's possible to start from the [Private S3 bucket AWS CloudFormation template](
   * Select Template is ready
   * Set Amazon S3 URL to https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-private-s3-bucket.yml
   * Next
-  * Set a stack name like shotgun-s3-bucket
-  * Set your S3 bucket name and your ShotGrid site name
+  * Set a stack name like {% include product %}-s3-bucket
+  * Set your S3 bucket name and your {% include product %} site name
   * Next
   * Accept `I acknowledge that AWS CloudFormation might create IAM resources`
   * Next
@@ -38,28 +38,28 @@ CORS policy on your S3 bucket will be minimally configured, allowing only the re
 
 The template will create an AWS Role with the following permissions on your bucket:
 
-* Allow ShotGrid to access your S3 bucket.
-* Allow the ShotGrid account to assume the role by setting the role Trust Relationship.
+* Allow {% include product %} to access your S3 bucket.
+* Allow the {% include product %} account to assume the role by setting the role Trust Relationship.
 
 ## Media Isolation Activation
 
-Please contact ShotGrid support via the dedicated Slack channel and provide the following information:
+Please contact {% include product %} support via the dedicated Slack channel and provide the following information:
   * S3 bucket name
   * AWS Region
-  * ShotGrid Role ARN
+  * {% include product %} Role ARN
 
-ShotGrid will configure your test site to use your own S3 bucket.
+{% include product %} will configure your test site to use your own S3 bucket.
 
 ## Validation
 
-At this stage, you should be able to upload and download media. The ShotGrid Transcoding Service should also be able to read, transcode and write back the thumbnails, filmstrip and web friendly versions of your media back to your S3 Bucket. To validate this:
+At this stage, you should be able to upload and download media. The {% include product %} Transcoding Service should also be able to read, transcode and write back the thumbnails, filmstrip and web friendly versions of your media back to your S3 Bucket. To validate this:
 
 1. Log in your Migration Test Site.
 2. From the Navigation Bar, go the the Media app
 3. Once in the Media App, drag and drop or upload an image or a video from your computer. If you didn't created a Project yet, you may have to create one first.
 4. A version should appear, with a thumbnail, in the Media App.
 5. Validate that you can playback the media by clicking the Play button.
-6. To validate that the media has been stored in your S3 bucket, from the media viewer, click on the cog and then select or hover over view source view. The HTTPS link should contain your bucket name.
+6. To validate that the media has been stored in your S3 bucket, from the media viewer, click on the cog and then select or hover over ‘view source’. The HTTPS link should contain your bucket name.
 
 ## Next Steps
 

--- a/docs/ko/trusted-solutions/tier1/setup/s3_replication.md
+++ b/docs/ko/trusted-solutions/tier1/setup/s3_replication.md
@@ -2,14 +2,14 @@
 layout: default
 title: Media Replication
 pagename: tier1-setup-s3_replication
-lang: en
+lang: ko
 ---
 
 # Media Replication
 
 ## Description
 
-It's possible to add S3 replication between two S3 buckets in different regions and configure ShotGrid to leverage it for faster access to media.
+It's possible to add S3 replication between two S3 buckets in different regions and configure {% include product %} to leverage it for faster access to media.
 
 ![S3 Replication Diagram](../images/tier1-s3-replication.png)
 
@@ -40,10 +40,10 @@ The `IP Adresses for S3 replication` preference can be edited in Site Preference
 # Setup steps
 
   * Create the replica S3 bucket in a new AWS region. See [Media Isolation](./s3_bucket.md)
-  * Update your existing ShotGrid role policy to allow ShotGrid to also access the replica bucket
+  * Update your existing {% include product %} role policy to allow {% include product %} to also access the replica bucket
   * Setup the replication rules on the primary S3 bucket. See [How do I add a replication rule to an S3 bucket?](https://docs.aws.amazon.com/AmazonS3/latest/user-guide/enable-replication.html#enable-replication-add-rule)
   * Setup a VPC + Direct Connect + S3 proxy in the new AWS region. See [Media Traffic Isolation](./media_segregation.md)
-  * Contact ShotGrid Support to configure your site to use the new S3 replica bucket, providing the following information:
+  * Contact {% include product %} Support to configure your site to use the new S3 replica bucket, providing the following information:
     * Replica Bucket Name
     * Replica Bucket Region
     * Replica S3 proxy URL

--- a/docs/ko/trusted-solutions/tier1/setup/setup.md
+++ b/docs/ko/trusted-solutions/tier1/setup/setup.md
@@ -2,10 +2,10 @@
 layout: default
 title: Setup
 pagename: tier1-setup
-lang: en
+lang: ko
 ---
 
-# ShotGrid Isolation Feature Set - Setup
+# {% include product %} Isolation Feature Set - Setup
 
 Isolation the isolation features are independent of each other, and can be activated independently of each other. Media replication have as pre-requisite for Media Isolation to be implemented.
 
@@ -40,7 +40,7 @@ Before you start working on your setup, [put a plan in place](./planning.md). Ch
 
 ## [Migration Test Site](./shotgun_poc_site.md)
 
-To help you setting up the Isolation features without breaking your production environment and to helping smooting the migration to your isolated environment, ShotGrid propose to use a test site on which to test your setup before applying the result to production.
+To help you setting up the Isolation features without breaking your production environment and to helping smooting the migration to your isolated environment, {% include product %} propose to use a test site on which to test your setup before applying the result to production.
 
 ## [Media Isolation](./s3_bucket.md)
 

--- a/docs/ko/trusted-solutions/tier1/setup/shotgun_poc_site.md
+++ b/docs/ko/trusted-solutions/tier1/setup/shotgun_poc_site.md
@@ -2,14 +2,14 @@
 layout: default
 title: Migration Test Site
 pagename: tier1-setup-shotgun_poc_site
-lang: en
+lang: ko
 ---
 
-# ShotGrid Migration Test Site
+# {% include product %} Migration Test Site
 
 Activating the isolation feature set is an intrusive procedure that can have an impact on the usability of your site. To prevent a production stopping event, we require clients to follow an approach where the configuration is first validated on a test site, before being applied to the production site.
 
-The ShotGrid team will create a temporary site to be used as a Proof of Concept for your ShotGrid Isolation deployment. Upon the successful completion of the setup process, your existing ShotGrid site can be migrated to your ShotGrid Isolation environment.
+The {% include product %} team will create a temporary site to be used as a Proof of Concept for your {% include product %} Isolation deployment. Upon the successful completion of the setup process, your existing {% include product %} site can be migrated to your {% include product %} Isolation environment.
 
 If your Migration Test Site has not been created yet, please reach out to our Support team through your Zendesk ticket or your dedicated on-boarding Slack Channel.
 

--- a/docs/ko/trusted-solutions/tier1/setup/traffic_segregation.md
+++ b/docs/ko/trusted-solutions/tier1/setup/traffic_segregation.md
@@ -2,31 +2,31 @@
 layout: default
 title: Web Traffic Isolation
 pagename: tier1-setup-traffic_segregation
-lang: en
+lang: ko
 ---
 
 # Web Traffic Isolation
 
-The goal is to set up an AWS PrivateLink to privately access your ShotGrid site.
+The goal is to set up an AWS PrivateLink to privately access your {% include product %} site.
 
 ## Set up PrivateLink to ShotGrid
 
-  * Ask ShotGrid support to provide you with the ShotGrid PrivateLink service name for your AWS region.
+  * Ask {% include product %} support to provide you with the {% include product %} PrivateLink service name for your AWS region.
 
-  * Update the private VPC CloudFormation stack you created earlier and set ShotGridPrivateServiceName parameter.
+  * Update the private VPC CloudFormation stack you created earlier and set {% include product %}PrivateServiceName parameter.
 
 ### Manual steps if needed
 
   * Add a new VPC Endpoint in your VPC
 
-  * For the security group, ShotGrid service only requires the inbound port tcp/443 to be open.
+  * For the security group, {% include product %} service only requires the inbound port tcp/443 to be open.
 
 ![Create endpoint](../images/tier1-endpoint-create_privatelink.png)
 
 
 ## DNS Configuration
 
-Provide your PrivateLink DNS name to ShotGrid support. We will setup a new private URL for your site that will look like `mystudio-staging.priv.shotgunstudio.com`.
+Provide your PrivateLink DNS name to {% include product %} support. We will setup a new private URL for your site that will look like `mystudio-staging.priv.shotgunstudio.com`.
 
 ## Validation
 

--- a/docs/ko/trusted-solutions/tier1/setup/tuning.md
+++ b/docs/ko/trusted-solutions/tier1/setup/tuning.md
@@ -2,7 +2,7 @@
 layout: default
 title: Fine Tuning
 pagename: tier1-setup-tuning
-lang: en
+lang: ko
 ---
 
 # Fine Tuning
@@ -11,17 +11,17 @@ lang: en
 
 ### S3 Infrequent Access
 
-We recommend enabling S3 Infrequent Access to easily reduce costs without impacting performance. For the ShotGrid Cloud hosted offering, we apply a policy for all objects older than one month.
+We recommend enabling S3 Infrequent Access to easily reduce costs without impacting performance. For the {% include product %} Cloud hosted offering, we apply a policy for all objects older than one month.
 
-With Infrequent Access, objects are stored at a lower cost. However, if they are accessed, it will involve an additional cost. ShotGrid has observed that one month was the right policy to use globally, but you may want to adapt that policy to your studio workflows as needed.
+With Infrequent Access, objects are stored at a lower cost. However, if they are accessed, it will involve an additional cost. {% include product %} has observed that one month was the right policy to use globally, but you may want to adapt that policy to your studio workflows as needed.
 
 Read more about S3 Infrequent Access and other storage classes [here](https://aws.amazon.com/s3/storage-classes/).
 
 ## S3 Bucket policy
 
-We recommend you restrict access to your S3 bucket to only your VPC and ShotGrid transcoding services IPs. There is an example policy, replace `your_vpc_id` and `your_s3_bucket` by your values.
+We recommend you restrict access to your S3 bucket to only your VPC and {% include product %} transcoding services IPs. There is an example policy, replace `your_vpc_id` and `your_s3_bucket` by your values.
 
-We strongly recommend you test media access and media transcoding in your migration test site right after applying the bucket policy changes to be sure your S3 bucket is still accessible from your VPC and from ShotGrid transcoders.
+We strongly recommend you test media access and media transcoding in your migration test site right after applying the bucket policy changes to be sure your S3 bucket is still accessible from your VPC and from {% include product %} transcoders.
 
 ```
 {
@@ -59,6 +59,7 @@ We strongly recommend you test media access and media transcoding in your migrat
                 },
                 "StringNotEquals": {
                     "aws:sourceVpc": [
+                        "vpc-2fd62a56",
                         "your_vpc_id"
                     ]
                 }

--- a/docs/zh_CN/trusted-solutions/cloud.md
+++ b/docs/zh_CN/trusted-solutions/cloud.md
@@ -2,14 +2,14 @@
 layout: default
 title: ShotGrid in the Cloud
 pagename: cloud-index
-lang: en
+lang: zh_CN
 ---
 
-# ShotGrid in the Cloud
+# {% include product %} in the Cloud
 
-## What is ShotGrid in the Cloud?
+## What is {% include product %} in the Cloud?
 
-ShotGrid Cloud is our default offering, hosted on AWS and built on top of Autodesk's Cloud technology platform. ShotGrid Cloud is the latest generation of our hosted service and is completely cloud based.
+{% include product %} Cloud is our default offering, hosted on AWS and built on top of Autodesk's Cloud technology platform. {% include product %} Cloud is the latest generation of our hosted service and is completely cloud based.
 
 ## Further Reading
 

--- a/docs/zh_CN/trusted-solutions/tier1.md
+++ b/docs/zh_CN/trusted-solutions/tier1.md
@@ -2,14 +2,14 @@
 layout: default
 title: Isolation Features
 pagename: tier1-index
-lang: en
+lang: zh_CN
 ---
 
 # Isolation Feature Set
 
 ![isolation-theme](./tier1/images/isolation_theme.jpg)
 
-The isolation feature set is an hybrid solution that satisfies strict security and legal requirements, while minimizing ShotGrid System Admin specific required knowledge and maintenance. These features enable creative studios to confidently meet their supplier’s and studio’s highly stringent security, privacy, and performance requirements—from the cloud.
+The isolation feature set is an hybrid solution that satisfies strict security and legal requirements, while minimizing {% include product %} System Admin specific required knowledge and maintenance. These features enable creative studios to confidently meet their supplier’s and studio’s highly stringent security, privacy, and performance requirements—from the cloud.
 
 Continue to [About the isolation feature set](./tier1/getting_started/about.md) for more details.
 
@@ -46,7 +46,7 @@ Go to [Setup](./tier1/setup/setup.md) if you are ready to activate the Isolation
 ### AWS Knowledge
 <!-- When updating this, also update knowledge/knowledge.md -->
 * [Connecting Your Studio With Your AWS VPC](./tier1/knowledge/connecting.md)
-* [ShotGrid AWS Direct Connect Onboarding](./tier1/knowledge/direct_connect_onboarding.md)
+* [{% include product %} AWS Direct Connect Onboarding](./tier1/knowledge/direct_connect_onboarding.md)
 * [S3](./tier1/knowledge/s3.md)
 * [VPC / IAM / Security Group](./tier1/knowledge/vpc_iam_sec.md)
 * [Direct Connect](./tier1/knowledge/direct_connect.md)

--- a/docs/zh_CN/trusted-solutions/tier1/features/features.md
+++ b/docs/zh_CN/trusted-solutions/tier1/features/features.md
@@ -2,7 +2,7 @@
 layout: default
 title: Features Description
 pagename: tier1-features
-lang: en
+lang: zh_CN
 ---
 
 # Isolation Feature Set

--- a/docs/zh_CN/trusted-solutions/tier1/features/media_isolation.md
+++ b/docs/zh_CN/trusted-solutions/tier1/features/media_isolation.md
@@ -2,11 +2,11 @@
 layout: default
 title: Media Isolation
 pagename: tier1-features-media-isolation
-lang: en
+lang: zh_CN
 ---
 
 # Media Isolation
-Media Isolation allows your studio to retain ownership and control of the media and attachments that you upload to ShotGrid. With Media Isolation, all the content that you upload to ShotGrid is stored in your studio's private S3 Bucket. Access to the media is provided to the ShotGrid services only, using [AWS AssumeRole keyless Security Token Service](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html).
+Media Isolation allows your studio to retain ownership and control of the media and attachments that you upload to {% include product %}. With Media Isolation, all the content that you upload to {% include product %} is stored in your studio's private S3 Bucket. Access to the media is provided to the {% include product %} services only, using [AWS AssumeRole keyless Security Token Service](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html).
 
 <img alt="media-isolation-overview" src="../images/media-isolation-overview.png" width="400">
 
@@ -16,13 +16,13 @@ Storing media and attachments in an S3 bucket that you own means that you remain
 <img alt="media-isolation-arch" src="../images/media-isolation-arch.png" width="400">
 
 ## More about Access
-When using ShotGrid to upload and download media it is transferred directly to / from AWS S3 without transiting through Autodesk infrastructure. ShotGrid will only access media in two situations:
-1. The ShotGrid Transcoding service will get read/write access once, soon after upload, when transcoding the media. See [Ephemeral Transcoding](../getting_started/about.md#ephemeral-transcoding) for details.
-2. When the ShotGrid service generates S3 Links to your sources and transcoded media.
+When using {% include product %} to upload and download media it is transferred directly to / from AWS S3 without transiting through Autodesk infrastructure. {% include product %} will only access media in two situations:
+1. The {% include product %} Transcoding service will get read/write access once, soon after upload, when transcoding the media. See [Ephemeral Transcoding](../getting_started/about.md#ephemeral-transcoding) for details.
+2. When the {% include product %} service generates S3 Links to your sources and transcoded media.
 
-This is rendered possible by leveraging [AWS AssumeRole keyless Security Token Service](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html). When setting up Media Isolation, an AWS Role allowing ShotGrid to access your media for the action listed above is created, and the ShotGrid service is allowed to assume that role.
+This is rendered possible by leveraging [AWS AssumeRole keyless Security Token Service](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html). When setting up Media Isolation, an AWS Role allowing {% include product %} to access your media for the action listed above is created, and the {% include product %} service is allowed to assume that role.
 
-ShotGrid Support staff do not have access to your S3 Bucket under any circumstances.
+{% include product %} Support staff do not have access to your S3 Bucket under any circumstances.
 
 ## Costs
 When activating Media Isolation the following costs, previously covered by Autodesk, become the responsibility of the client:
@@ -30,4 +30,4 @@ When activating Media Isolation the following costs, previously covered by Autod
 2. **S3 Bandwidth.** Bandwidth out of the S3 bucket will be assumed by the customer.
 
 ## What Media Isolation is not providing
-Activating Media Isolation doesn't guarantee that the access to your ShotGrid site or media takes place within a closed network. 
+Activating Media Isolation doesn't guarantee that the access to your {% include product %} site or media takes place within a closed network. 

--- a/docs/zh_CN/trusted-solutions/tier1/features/media_replication.md
+++ b/docs/zh_CN/trusted-solutions/tier1/features/media_replication.md
@@ -2,12 +2,12 @@
 layout: default
 title: Media Replication
 pagename: tier1-features-media-replication
-lang: en
+lang: zh_CN
 ---
 
 # Media Replication
 
-ShotGrid is compatible with the S3 Cross-Region replication feature, allowing your users located in different regions to read from the region closer to them in order to reduce latency and increase throughput. Replication to one region is currently supported.
+{% include product %} is compatible with the S3 Cross-Region replication feature, allowing your users located in different regions to read from the region closer to them in order to reduce latency and increase throughput. Replication to one region is currently supported.
 
 <img alt="media-replication-overview" src="../images/media-replication-overview.png" width="400">
 
@@ -15,23 +15,23 @@ ShotGrid is compatible with the S3 Cross-Region replication feature, allowing yo
 Media Isolation is required in order to elect Media Replication.
 
 ## Configuration by users
-When using Media Replication, each user can customize which region data is read from. A user can either specify the region to use, or use automatic mode. In automatic mode ShotGrid selects the replica determined by the user's IP address using IP ranges specified in the Isolation Preferences.
+When using Media Replication, each user can customize which region data is read from. A user can either specify the region to use, or use automatic mode. In automatic mode {% include product %} selects the replica determined by the user's IP address using IP ranges specified in the Isolation Preferences.
 
 <img alt="media-replication-preferences" src="../images/media-replication-preferences.png" width="400">
 
 ## How it works
-ShotGrid can be configured to read from up to two different buckets. Using the [AWS S3 Replication](https://docs.aws.amazon.com/AmazonS3/latest/dev/replication.html) feature, you can configure replication between buckets in different regions, and then consume media from the region closest to your users. It is important to underline that media is always uploaded to the main bucket.
+{% include product %} can be configured to read from up to two different buckets. Using the [AWS S3 Replication](https://docs.aws.amazon.com/AmazonS3/latest/dev/replication.html) feature, you can configure replication between buckets in different regions, and then consume media from the region closest to your users. It is important to underline that media is always uploaded to the main bucket.
 
 <img alt="media-replication-arch" src="../images/media-replication-arch.png" width="400">
 
 Following AWS service level agreement, S3 guarantees the replication of 99.99% of the object within 15 minutes.
 
 ### Replication Delay
-A small amount of time, typically under 15 minutes, is required before replication happens. The replication time depends on the size of the object to replicate. In order to alleviate that replication delay, ShotGrid will, for a small period of time, generate links from to object in the source bucket instead of the replica. The duration of this transitional state in configurable in the Isolation Preferences.
+A small amount of time, typically under 15 minutes, is required before replication happens. The replication time depends on the size of the object to replicate. In order to alleviate that replication delay, {% include product %} will, for a small period of time, generate links from to object in the source bucket instead of the replica. The duration of this transitional state in configurable in the Isolation Preferences.
 
 ## Costs
 Activating the Media Replication feature can increase your AWS costs considerabibly. Before activating, be aware that:
-1. Your S3 cost linked to ShotGrid usage will more or less double, because the media is now stored in two regions.
+1. Your S3 cost linked to {% include product %} usage will more or less double, because the media is now stored in two regions.
 2. You will be charged for the transfer cost between the source and the destination region. See [AWS S3 CRR and the destination region](https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-and-other-bucket-configs.html#replication-and-dest-region) for more details.
 
 ## Next Steps

--- a/docs/zh_CN/trusted-solutions/tier1/features/media_traffic_isolation.md
+++ b/docs/zh_CN/trusted-solutions/tier1/features/media_traffic_isolation.md
@@ -2,7 +2,7 @@
 layout: default
 title: Media Traffic Isolation
 pagename: tier1-features-media-traffic-isolation
-lang: en
+lang: zh_CN
 ---
 
 # Media Traffic Isolation
@@ -15,7 +15,7 @@ Communication between your client systems and S3 bucket targets a number of AWS 
 An S3 Proxy component is deployed within your VPC; which is then used as the endpoint for all S3 communication. It can also be made publicly available using AWS Global Accelerator. 
 
 ## How it works
-ShotGrid can be configured to use an S3 Proxy address to communicate with your S3 bucket. Deploying the S3 Proxy component within your VPC makes it possible to isolate traffic from the public Internet completely, or to allow more tightly controlled access from the Internet to your media.
+{% include product %} can be configured to use an S3 Proxy address to communicate with your S3 bucket. Deploying the S3 Proxy component within your VPC makes it possible to isolate traffic from the public Internet completely, or to allow more tightly controlled access from the Internet to your media.
 
 <img alt="media-traffic-isolation-arch" src="../images/media-traffic-isolation-arch.png" width="400">
 

--- a/docs/zh_CN/trusted-solutions/tier1/features/web_traffic_isolation.md
+++ b/docs/zh_CN/trusted-solutions/tier1/features/web_traffic_isolation.md
@@ -2,12 +2,12 @@
 layout: default
 title: Web Traffic Isolation
 pagename: tier1-features-web-traffic-isolation
-lang: en
+lang: zh_CN
 ---
 
 # Web Traffic Isolation
 
-Communication between your client systems and your Shotgun site will traverse the open Internet by default. Web Traffic Isolation allows you to restrict access to your Shotgun site from the public Internet entirely and ensure that all traffic transits directly between your AWS VPC and Autodesk's AWS VPC.
+Communication between your client systems and your {% include product %} site will traverse the open Internet by default. Web Traffic Isolation allows you to restrict access to your {% include product %} site from the public Internet entirely and ensure that all traffic transits directly between your AWS VPC and Autodesk's AWS VPC.
 
 <img alt="web-traffic-isolation-overview" src="../images/web-traffic-isolation-overview.png" width="400">
 

--- a/docs/zh_CN/trusted-solutions/tier1/getting_started/about.md
+++ b/docs/zh_CN/trusted-solutions/tier1/getting_started/about.md
@@ -2,12 +2,12 @@
 layout: default
 title: About the Isolation Feature Set
 pagename: tier1-getting_started-about
-lang: en
+lang: zh_CN
 ---
 
 # What is the Isolation Feature Set
 
-The isolation feature set combines our Cloud Hosted Platform with client-managed AWS resources to provide a solution that satisfies the most stringent security and privacy requirements. Clients retain control of their sensitive content without having to host ShotGrid on their infrastructure.
+The isolation feature set combines our Cloud Hosted Platform with client-managed AWS resources to provide a solution that satisfies the most stringent security and privacy requirements. Clients retain control of their sensitive content without having to host {% include product %} on their infrastructure.
 
 Leveraging the isolation feature set has the following advantages over the Standard offering:
 
@@ -15,28 +15,28 @@ Leveraging the isolation feature set has the following advantages over the Stand
 * **Web Traffic Isolation** from the public internet
 * **Media Traffic Isolation** from the public internet
 * **Media Replication** allowing you to replicate media in one additional AWS Region
-* Access to fully managed ShotGrid Cloud Services
+* Access to fully managed {% include product %} Cloud Services
 * Automatic and continuous version upgrades
 * Ephemeral compute + in-memory segration between clients
 
-In a nutshell, this means that with the isolation features, your ShotGrid site and the data related to it cannot be reached by anyone outside of your studio network.
+In a nutshell, this means that with the isolation features, your {% include product %} site and the data related to it cannot be reached by anyone outside of your studio network.
 
-The isolation feature set is a solution that requires less upkeep, as well as less IT/System Administrator knowledge and skills, than hosting ShotGrid on-premise. The list of advantages compared to on-premise includes, but is not limited to:
+The isolation feature set is a solution that requires less upkeep, as well as less IT/System Administrator knowledge and skills, than hosting {% include product %} on-premise. The list of advantages compared to on-premise includes, but is not limited to:
 
-* No ShotGrid specific knowledge required
-* No manual ShotGrid updates required
+* No {% include product %} specific knowledge required
+* No manual {% include product %} updates required
 * Very low level of maintenance required for the AWS components
 
 ## Media isolation feature
-Media Isolation allows your studio to keep the ownership and control of the media and attachments that you upload to ShotGrid. With Media Isolation, all the content that you upload to ShotGrid can be store in your studio private S3 bucket. Access to the media is provided to the ShotGrid service only, using AWS AssumeRole keyless Security Token Service. Your studio remains in control of the assets and the access to the assets, access that you can revoke at will.
+Media Isolation allows your studio to keep the ownership and control of the media and attachments that you upload to {% include product %}. With Media Isolation, all the content that you upload to {% include product %} can be store in your studio private S3 bucket. Access to the media is provided to the {% include product %} service only, using AWS AssumeRole keyless Security Token Service. Your studio remains in control of the assets and the access to the assets, access that you can revoke at will.
 
 ## Traffic isolation features
-Media and Web traffic isolation features can be enabled to prevent your traffic from being routed on the public internet, limiting it to the AWS backbone and your studio network. The traffic between ShotGrid Services and your studio stays in closed network, never going outside AWS or your Studio network.
+Media and Web traffic isolation features can be enabled to prevent your traffic from being routed on the public internet, limiting it to the AWS backbone and your studio network. The traffic between {% include product %} Services and your studio stays in closed network, never going outside AWS or your Studio network.
 
 With the Media Traffic Isolation feature activated, the media will only leave your studio infrastructure once to get transcoded.
 
 ## Media Replication
-ShotGrid is compatible with the S3 Cross-Region replication feature, allowing your users located in different regions to read from the region closer to them in order to reduce latency and increase throughput. Replication to one region is currently supported.
+{% include product %} is compatible with the S3 Cross-Region replication feature, allowing your users located in different regions to read from the region closer to them in order to reduce latency and increase throughput. Replication to one region is currently supported.
 
 
 # Eligibility
@@ -46,26 +46,26 @@ The Isolation feature set is available for all Super Awesome clients. See [Getti
 
 # What the Isolation Feature Set is not
 
-The isolation feature set is not a completely isolated solution. Both the compute services and the database services are shared amongst clients, and managed by ShotGrid. From a hardware standpoint, the isolation features does not guarantee complete physical isolation. However, ShotGrid services are guaranteeing isolation at the memory level. Processes are never reused to answer requests from different clients during their lifetime. Client metadata is stored in different databases. Client media is individually stored on S3.
+The isolation feature set is not a completely isolated solution. Both the compute services and the database services are shared amongst clients, and managed by {% include product %}. From a hardware standpoint, the isolation features does not guarantee complete physical isolation. However, {% include product %} services are guaranteeing isolation at the memory level. Processes are never reused to answer requests from different clients during their lifetime. Client metadata is stored in different databases. Client media is individually stored on S3.
 
 
 # High Level Architecture
 ![tier1-arch](../images/tier1-about-arch.png)
 
-The ShotGrid cloud service  can be decoupled at a high level in 3 parts:
+The {% include product %} cloud service  can be decoupled at a high level in 3 parts:
 
-**Compute Stack:** The part of the ShotGrid Service that handles client requests and serves data to the client.
+**Compute Stack:** The part of the {% include product %} Service that handles client requests and serves data to the client.
 
 **Data Stack:** Metadata storage (databases).
 
-**Media Storage:** Where the client's attachments, media, and assets are stored. ShotGrid uses AWS S3 to store client content.
+**Media Storage:** Where the client's attachments, media, and assets are stored. {% include product %} uses AWS S3 to store client content.
 
-Please read [Securing Studio IP in AWS: Cloud-based VFX Project Management with Autodesk ShotGrid](https://aws.amazon.com/blogs/media/securing-studio-ip-in-aws-cloud-based-vfx-project-management-with-autodesk-shotgun/) for more details about the architecture.
+Please read [Securing Studio IP in AWS: Cloud-based VFX Project Management with Autodesk {% include product %}](https://aws.amazon.com/blogs/media/securing-studio-ip-in-aws-cloud-based-vfx-project-management-with-autodesk-shotgun/) for more details about the architecture.
 
 ## Ephemeral compute and memory isolation
-Even if clients share the same infrastructure, ShotGrid guarantees a complete memory isolation, both in transit and at rest, of client data. This makes ShotGrid less prone to data leaking due to architecture flaws or software vulnerabilities exploiting memory, like buffer overflow.
+Even if clients share the same infrastructure, {% include product %} guarantees a complete memory isolation, both in transit and at rest, of client data. This makes {% include product %} less prone to data leaking due to architecture flaws or software vulnerabilities exploiting memory, like buffer overflow.
 
 ## Ephemeral transcoding
 ![tier1-transcoding](../images/tier1-about-transcoding.png)
 
-Everytime media is uploaded to ShotGrid, the transcoding service is invoked to create a web friendly versions of your assets. That process happens only once, after the initial upload. The media is directly uploaded from the client to S3, from where it is fetched by the ShotGrid Transcoding Service. Each transcoding job is handled by a single container, which is killed after that unique job. The only place the media temporarily lives is in the container memory. The ShotGrid Transcoding service doesn't store permanently a copy of your media.
+Everytime media is uploaded to {% include product %}, the transcoding service is invoked to create a web friendly versions of your assets. That process happens only once, after the initial upload. The media is directly uploaded from the client to S3, from where it is fetched by the {% include product %} Transcoding Service. Each transcoding job is handled by a single container, which is killed after that unique job. The only place the media temporarily lives is in the container memory. The {% include product %} Transcoding service doesn't store permanently a copy of your media.

--- a/docs/zh_CN/trusted-solutions/tier1/getting_started/getting_started.md
+++ b/docs/zh_CN/trusted-solutions/tier1/getting_started/getting_started.md
@@ -2,7 +2,7 @@
 layout: default
 title: Getting Started
 pagename: tier1-getting_started
-lang: en
+lang: zh_CN
 ---
 
 # Isolation Feature Set - Getting Started

--- a/docs/zh_CN/trusted-solutions/tier1/getting_started/onboarding.md
+++ b/docs/zh_CN/trusted-solutions/tier1/getting_started/onboarding.md
@@ -2,7 +2,7 @@
 layout: default
 title: Onboarding Process
 pagename: tier1-getting_started-onboarding
-lang: en
+lang: zh_CN
 ---
 
 # Onboarding Process
@@ -11,7 +11,7 @@ Leveraging the isolation features requires adopters to become AWS users. In orde
 
 Autodesk and Amazon will provide dedicated resources during the onboarding process to help you on this journey.
 
-To start the on-boarding process for any of the Isolation features, please open a [ShotGrid Support ticket](https://support.shotgunsoftware.com/hc/en-us/requests/new), before proceeding with [your setup](../setup/setup.md)
+To start the on-boarding process for any of the Isolation features, please open a [{% include product %} Support ticket](https://support.shotgunsoftware.com/hc/en-us/requests/new), before proceeding with [your setup](../setup/setup.md)
 
 ## Onboarding Process Overview
 
@@ -23,19 +23,19 @@ During the onboarding process, you'll have direct access to Autodesk and AWS Lea
 
 **Tech Deep Dive:**  OPTIONAL. Deeper technical dive into isolation features. This meeting can be combined with the Tech Briefing.
 
-**Kickoff Meeting:**	AWS and ShotGrid Leaders review the setup process with the you.
+**Kickoff Meeting:**	AWS and {% include product %} Leaders review the setup process with the you.
 
-**Setup / Test / Validation:**	Iterative installation process where you connect your AWS resources to ShotGrid, and activate the isolation features.
+**Setup / Test / Validation:**	Iterative installation process where you connect your AWS resources to {% include product %}, and activate the isolation features.
 
-**Training:** OPTIONAL. Help sessions, if needed, as you ramp up on the AWS/ShotGrid technologies required to securely set-up the isolation features for your site.
+**Training:** OPTIONAL. Help sessions, if needed, as you ramp up on the AWS/{% include product %} technologies required to securely set-up the isolation features for your site.
 
 ## Onboarding Resources
 
-**ShotGrid Community:** The [ShotGrid Isolation Community](https://community.shotgunsoftware.com/c/trusted-solutions/isolation/34) forum can be used to ask questions that can be answered by either ShotGrid Experts or other isolation features users. This should be your first stop when asking general questions about isolation features, during setup and beyond.
+**{% include product %} Community:** The [{% include product %} Isolation Community](https://community.shotgridsoftware.com/c/trusted-solutions/isolation/34) forum can be used to ask questions that can be answered by either {% include product %} Experts or other isolation features users. This should be your first stop when asking general questions about isolation features, during setup and beyond.
 
-**Private Slack Channel:** During the onboarding, you will be given access to a dedicated Autodesk Slack Channel. Your ShotGrid and AWS Leaders will be available for quick feedback, answers, and ad-hoc meetings to help you progress as fast as possible with your ShotGrid Isolation setup. This channel will be available only for the onboarding period.
+**Private Slack Channel:** During the onboarding, you will be given access to a dedicated Autodesk Slack Channel. Your {% include product %} and AWS Leaders will be available for quick feedback, answers, and ad-hoc meetings to help you progress as fast as possible with your {% include product %} Isolation setup. This channel will be available only for the onboarding period.
 
-**ShotGrid Support:** A [ShotGrid Support](https://support.shotgunsoftware.com/hc/en-us/requests/new) ticket will be used to track your onboarding at a higher level. Once your ShotGrid Isolation setup is complete, follow-up support tickets can be opened with the support team as needed.
+**{% include product %} Support:** A [{% include product %} Support](https://support.shotgunsoftware.com/hc/en-us/requests/new) ticket will be used to track your onboarding at a higher level. Once your {% include product %} Isolation setup is complete, follow-up support tickets can be opened with the support team as needed.
 
 ## Next Steps
 

--- a/docs/zh_CN/trusted-solutions/tier1/getting_started/responsibilities.md
+++ b/docs/zh_CN/trusted-solutions/tier1/getting_started/responsibilities.md
@@ -2,7 +2,7 @@
 layout: default
 title: Client Responsibilities
 pagename: tier1-getting_started-responsibilities
-lang: en
+lang: zh_CN
 ---
   
 # Client Responsibilities
@@ -15,7 +15,7 @@ You are entirely responsible for the validity, security, and execution of the Is
  
 Autodesk is available during the process for assistance, but the configuration of Isolation features in Your AWS Account is to be executed by You on Your own.
 
-Isolation feature set activation requires the ShotGrid Support team's intervention. Activation delays are to be expected and will depend on demand. You understand that an estimated period of 2-8 weeks is usually required to complete the setup necessary to implement the isolation feature set. The setup time is highly dependent on your cooperation, so please plan to dedicate resources for the setup before beginning the onboarding process.
+Isolation feature set activation requires the {% include product %} Support team's intervention. Activation delays are to be expected and will depend on demand. You understand that an estimated period of 2-8 weeks is usually required to complete the setup necessary to implement the isolation feature set. The setup time is highly dependent on your cooperation, so please plan to dedicate resources for the setup before beginning the onboarding process.
 
 Autodesk does not guarantee any timeline for setup completion.
 
@@ -24,13 +24,13 @@ Autodesk does not guarantee any timeline for setup completion.
 |Type|	Description / Agreement |	Responsibility	| Available for Assistance|
 |--------|-----|----------|---------|
 |AWS Knowledge	|	Acquiring the AWS-specific knowledge required to set up the isolation features.	|You	|N/A|
-|S3|Setting up the S3 Bucket that will host Your media Securing access to the S3 Bucket. Additional high-availability measures (versioning, bucket replication, etc.)	|You	|ShotGrid and *AWS|
+|S3|Setting up the S3 Bucket that will host Your media Securing access to the S3 Bucket. Additional high-availability measures (versioning, bucket replication, etc.)	|You	|{% include product %} and *AWS|
 |Closed VPC	|Setting up DirectConnect/VPN, etc. to allow closed access to the VPC. Securing the VPC by putting the correct Security Groups in place.	|You	|*AWS |
-|Media Isolation	|Creating the S3 end-points. Deploying the S3 Proxy.	|You|	ShotGrid and *AWS |
-|Traffic Isolation	|Creating VPCs. Creating Subnets.|	You|ShotGrid|
-|Private Access Point|Checking that the access point is only available from Your network.|	ShotGrid|	N/A|
-|Monitoring and Reliability|Maintaining uptime up to Autodesk standards. High availability and redundancy of Cloud Services. Metadata and database resiliency and redundancy. Maintaining Recovery Point Objective (RPO) for metadata and database.	|ShotGrid|N/A|
-|Service Level Objective|Maintaining ShotGrid target RPO and RTO (See [ShotGrid Security White Paper](https://support.shotgunsoftware.com/hc/en-us/articles/114094526153-Shotgun-security-white-paper) for more details).|ShotGrid|	N/A|
-|Security and Governance |Maintaining the ShotGrid Cloud Services that Isolation clients are interfacing with, so that they are meeting expectations in terms of security, vulnerability patching, scanning, auditing, etc. (See [ShotGrid Security White Paper](https://support.shotgunsoftware.com/hc/en-us/articles/114094526153-Shotgun-security-white-paper) for more details).|	ShotGrid	|N/A|
+|Media Isolation	|Creating the S3 end-points. Deploying the S3 Proxy.	|You|	{% include product %} and *AWS |
+|Traffic Isolation	|Creating VPCs. Creating Subnets.|	You|{% include product %}|
+|Private Access Point|Checking that the access point is only available from Your network.|	{% include product %}|	N/A|
+|Monitoring and Reliability|Maintaining uptime up to Autodesk standards. High availability and redundancy of Cloud Services. Metadata and database resiliency and redundancy. Maintaining Recovery Point Objective (RPO) for metadata and database.	|{% include product %}|N/A|
+|Service Level Objective|Maintaining {% include product %} target RPO and RTO (See [{% include product %} Security White Paper](https://support.shotgunsoftware.com/hc/en-us/articles/114094526153-Shotgun-security-white-paper) for more details).|{% include product %}|	N/A|
+|Security and Governance |Maintaining the {% include product %} Cloud Services that Isolation clients are interfacing with, so that they are meeting expectations in terms of security, vulnerability patching, scanning, auditing, etc. (See [{% include product %} Security White Paper](https://support.shotgunsoftware.com/hc/en-us/articles/114094526153-Shotgun-security-white-paper) for more details).|	{% include product %}	|N/A|
 
 *You are solely responsible to seek or obtain any support services AWS may provide under any existing relationship between You and AWS. Autodesk teams are not parties to Your relationship with AWS and therefore not responsible or liable for any services or lack thereof provided by AWS to You. 

--- a/docs/zh_CN/trusted-solutions/tier1/knowledge/aws.md
+++ b/docs/zh_CN/trusted-solutions/tier1/knowledge/aws.md
@@ -2,7 +2,7 @@
 layout: default
 title: AWS Knowledge
 pagename: tier1-knowledge-aws
-lang: en
+lang: zh_CN
 ---
 
 # AWS Knowledge

--- a/docs/zh_CN/trusted-solutions/tier1/knowledge/connecting.md
+++ b/docs/zh_CN/trusted-solutions/tier1/knowledge/connecting.md
@@ -2,7 +2,7 @@
 layout: default
 title: Connecting Your Studio With Your AWS VPC
 pagename: tier1-knowledge-connecting
-lang: en
+lang: zh_CN
 ---
 
 # Connecting Your Studio With Your AWS VPC

--- a/docs/zh_CN/trusted-solutions/tier1/knowledge/direct_connect.md
+++ b/docs/zh_CN/trusted-solutions/tier1/knowledge/direct_connect.md
@@ -2,7 +2,7 @@
 layout: default
 title: Direct Connect
 pagename: tier1-knowledge-direct_connect
-lang: en
+lang: zh_CN
 ---
 
 # Direct Connect

--- a/docs/zh_CN/trusted-solutions/tier1/knowledge/direct_connect_onboarding.md
+++ b/docs/zh_CN/trusted-solutions/tier1/knowledge/direct_connect_onboarding.md
@@ -2,9 +2,10 @@
 layout: default
 title: ShotGrid AWS Direct Connect Onboarding
 pagename: tier1-knowledge-direct_connect_onboarding
+lang: zh_CN
 ---
 
-# ShotGrid AWS Direct Connect Onboarding
+# {% include product %} AWS Direct Connect Onboarding
 
 
 ## Introduction
@@ -40,7 +41,7 @@ If you answer “yes” to the following, then request a dedicated Direct Connec
 
 If you answer “yes” to the following, then request a dedicated Direct Connect connection through the AWS Console and select a Partner to assist (Option 1b):
 
-- Are you planning to use AWS Direct Connect to connect to other AWS resources outside of ShotGrid?
+- Are you planning to use AWS Direct Connect to connect to other AWS resources outside of {% include product %}?
 - Do you have the time and resources to complete the setup?
 - Are you looking for any one of the following - 1Gbps, 10Gbps port, or a dedicated connection?
 

--- a/docs/zh_CN/trusted-solutions/tier1/knowledge/endpoints.md
+++ b/docs/zh_CN/trusted-solutions/tier1/knowledge/endpoints.md
@@ -2,7 +2,7 @@
 layout: default
 title: VPC Endpoints
 pagename: tier1-knowledge-endpoints
-lang: en
+lang: zh_CN
 ---
 
 # VPC Endpoints

--- a/docs/zh_CN/trusted-solutions/tier1/knowledge/knowledge.md
+++ b/docs/zh_CN/trusted-solutions/tier1/knowledge/knowledge.md
@@ -2,7 +2,7 @@
 layout: default
 title: Knowledge
 pagename: tier1-knowledge
-lang: en
+lang: zh_CN
 ---
 
 # Generic Knowledge
@@ -10,7 +10,7 @@ lang: en
 ## In This Section
 <!-- When updating this, also update tier1.md -->
 * [Connecting Your Studio With Your AWS VPC](./connecting.md)
-* [ShotGrid AWS Direct Connect Onboarding](./direct_connect_onboarding.md)
+* [{% include product %} AWS Direct Connect Onboarding](./direct_connect_onboarding.md)
 * [S3](./s3.md)
 * [VPC / IAM / Security Group](./vpc_iam_sec.md)
 * [Direct Connect](./direct_connect.md)

--- a/docs/zh_CN/trusted-solutions/tier1/knowledge/private_link.md
+++ b/docs/zh_CN/trusted-solutions/tier1/knowledge/private_link.md
@@ -2,11 +2,11 @@
 layout: default
 title: Private Link
 pagename: tier1-knowledge-private_link
-lang: en
+lang: zh_CN
 ---
 
 # Private Link
 
 [AWS PrivateLink](https://aws.amazon.com/privatelink/) is an AWS service that connects different AWS VPCs without going through the public internet. 
 
-In conjunction with [AWS Direct Connect](./direct_connect.md), PrivateLink helps create a dedicated connection between your studio and ShotGrid's infrastructure.
+In conjunction with [AWS Direct Connect](./direct_connect.md), PrivateLink helps create a dedicated connection between your studio and {% include product %}'s infrastructure.

--- a/docs/zh_CN/trusted-solutions/tier1/knowledge/s3.md
+++ b/docs/zh_CN/trusted-solutions/tier1/knowledge/s3.md
@@ -2,11 +2,11 @@
 layout: default
 title: S3
 pagename: tier1-knowledge-s3
-lang: en
+lang: zh_CN
 ---
 
 # S3
 
-[Amazon S3](https://aws.amazon.com/s3/) is an object storage service offered by AWS. It can be thought of as a highly durable storage space in the cloud. ShotGrid uses S3 to store uploaded media and files.
+[Amazon S3](https://aws.amazon.com/s3/) is an object storage service offered by AWS. It can be thought of as a highly durable storage space in the cloud. {% include product %} uses S3 to store uploaded media and files.
 
-In order to use ShotGrid isolation features, you will bring your own S3 bucket and configure ShotGrid to use it for storage. Please refer to our [S3 Bucket Setup article](../setup/s3_bucket.md) for details on how to do this.
+In order to use {% include product %} isolation features, you will bring your own S3 bucket and configure {% include product %} to use it for storage. Please refer to our [S3 Bucket Setup article](../setup/s3_bucket.md) for details on how to do this.

--- a/docs/zh_CN/trusted-solutions/tier1/knowledge/vpc_iam_sec.md
+++ b/docs/zh_CN/trusted-solutions/tier1/knowledge/vpc_iam_sec.md
@@ -2,7 +2,7 @@
 layout: default
 title: VPC / IAM / Security Group
 pagename: tier1-knowledge-vpc_iam_sec
-lang: en
+lang: zh_CN
 ---
 
 # VPC / IAM / Security Group
@@ -11,6 +11,6 @@ lang: en
 
 Within a VPC, [security groups](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html) act as a basic firewall and control what inbound and outbound connections are permitted to each given resource. For example, a security group can allow inbound **HTTPS** traffic to a proxy server but block all other inbound traffic.
 
-With [AWS Identity and Access Management (IAM)](https://aws.amazon.com/iam/), access to AWS resources and services can be controlled at a more fine-grained level. For example, IAM can be leveraged to control who or which resources can access S3 buckets used by ShotGrid.
+With [AWS Identity and Access Management (IAM)](https://aws.amazon.com/iam/), access to AWS resources and services can be controlled at a more fine-grained level. For example, IAM can be leveraged to control who or which resources can access S3 buckets used by {% include product %}.
 
-All three of the above features are used in the ShotGrid isolation features implementation to ensure that you securely connect your closed VPC to ShotGrid and allow access to the [media S3 buckets](../setup/s3_bucket.md).
+All three of the above features are used in the {% include product %} isolation features implementation to ensure that you securely connect your closed VPC to {% include product %} and allow access to the [media S3 buckets](../setup/s3_bucket.md).

--- a/docs/zh_CN/trusted-solutions/tier1/learn/learn.md
+++ b/docs/zh_CN/trusted-solutions/tier1/learn/learn.md
@@ -2,9 +2,9 @@
 layout: default
 title: Learn
 pagename: tier1-learn
-lang: en
+lang: zh_CN
 ---
 
-# ShotGrid Isolation - Learn
+# {% include product %} Isolation - Learn
 
-This section will host a learning curriculum for ShotGrid Isolation features n the near future.
+This section will host a learning curriculum for {% include product %} Isolation features n the near future.

--- a/docs/zh_CN/trusted-solutions/tier1/setup/media_segregation.md
+++ b/docs/zh_CN/trusted-solutions/tier1/setup/media_segregation.md
@@ -2,32 +2,26 @@
 layout: default
 title: Media Traffic Isolation
 pagename: tier1-setup-media_segregation
-lang: en
+lang: zh_CN
 ---
 
-# Media Traffic Isolation
+# Media Traffic Isolation using AWS PrivateLink for Amazon S3
 
 {% include info title="Disclaimer" content="This documentation is provided solely as an example. It explains how to set up your ShotGrid Isolation environment so that it can be connected to ShotGrid cloud infrastructure. Please adapt it to your studio security requirements as needed. As ShotGrid has no visibility on your AWS Account, ensuring that this account is secure is a client responsibility." %}
 
-The media traffic isolation feature allows your users to access media in your AWS S3 bucket privately (not transiting over the public Internet). Please note that if you have a multi-region setup and that leverages the ShotGrid Transcoding service there may still be instances where media transits across the public Internet. Reach out to our support team for more details.
+The media traffic isolation feature allows your users to access media in your AWS S3 bucket privately (not transiting over the public Internet). Please note that if you have a multi-region setup and that leverages the {% include product %} Transcoding service there may still be instances where media transits across the public Internet. Reach out to our support team for more details.
 
 Media Isolation activation is a pre-requisite to enable this feature. If you haven't done so already, see [Media Isolation](./s3_bucket.md).
 
 ## Set up a VPC in your S3 bucket AWS region
 
-{% include info title="Disclaimer" content="Before starting, decide whether your S3 proxy will be privately accessible within your VPC or publicly accessible via the Internet and choose the relevant templates in the following instructions." %}
-
-You will need to deploy a VPC with the required VPC endpoints. We provide both [private VPC](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-private-vpc.yml) and [public VPC](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-private-vpc.yml) CloudFormation templates as starting points. These template create the necessary VPCs, subnets and VPC endpoints.
+You will need to deploy a VPC with the required VPC endpoint. We provide a [private VPC](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-private-vpc-s3-privatelink.yml) CloudFormation templates as starting points. This template create the necessary VPC, subnets and VPC endpoint.
 
 * Create a [new CloudFormation stack](https://console.aws.amazon.com/cloudformation/home?#/stacks/create/template)
 * Select Template is ready
-* Set Amazon S3 URL depending upon your desired configuration
-  * Private VPC (default):
-    [`https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-private-vpc.yml`](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-private-vpc.yml)
-  * Public VPC:
-    [`https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-public-vpc.yml`](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-public-vpc.yml)
+* Set Amazon S3 URL to [`https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-private-vpc-s3-privatelink.yml`](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-private-vpc-s3-privatelink.yml)
 * Click Next
-* Set a stack name. Eg. `shotgun-vpc`
+* Set a stack name. Eg. `{% include product %}-vpc`
 * Choose network ranges that doesn't conflict with your studio network and set subnet CIDR values accordingly
 * Set your S3 bucket name
 * Click Next
@@ -43,85 +37,27 @@ Options provided by AWS:
 
 ## Add an S3 endpoint to your VPC
 
-{% include info title="Note" content="This step should only be performed if the CloudFormation template was *not* used when configuring [Media Isolation](./s3_bucket.md)." %}
+{% include info title="Note" content="This step should only be performed if the CloudFormation template was *not* used." %}
 
-![Add endpoint](../images/tier1-endpoint-create-1.png)
-![Add endpoint](../images/tier1-endpoint-create-2.png)
-![Add endpoint](../images/tier1-endpoint-create-3.png)
+Simply add an `com.amazonaws.us-west-2.s3` Interface VPC Endpoint to your existing VPC. Make sure the associated security group allow traffic from your site network.
 
-## Set up S3 proxy
+### Add the VPC to your S3 bucket policy
 
-You will need to deploy an S3 proxy in your VPC to forward traffic to the S3 VPC endpoint. We provide both [private](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy.yml) and [public](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy-public.yml) S3 proxy CloudFormation templates as starting points for this purpose. These will create the necessary Elastic Container Service (ECS) cluster and other resources to run the S3 proxy on AWS Fargate behind an AWS Application Load Balancer (ALB).
-
-### Make the Docker image available from a private AWS ECR repository
-
-* Create a [new Elastic Container Registry (ECR) repository](https://console.aws.amazon.com/ecr/create-repository)
-* Name the repository `s3-proxy`
-* Upload the s3-proxy Docker image to the newly created ECR repository
-  * [Install Docker](https://docs.docker.com/get-docker/) on your workstation
-  * Follow the `docker login` instructions shown by clicking the *View push commands* button
-  * Run the following commands, substituting the ECR endpoint in the example for yours:
-    ```
-    docker pull quay.io/shotgun/s3-proxy:1.0.6
-    docker tag quay.io/shotgun/s3-proxy:1.0.6 627791357434.dkr.ecr.us-west-2.amazonaws.com/s3-proxy:1.0.6
-    docker push 627791357434.dkr.ecr.us-west-2.amazonaws.com/s3-proxy:1.0.6
-    ```
-
-### Create S3 proxy CloudFormation stack
-
-Create a new stack in AWS Console using either the [private](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy.yml) or [public](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy-public.yml) CloudFormation template.
-
-* Create a [new CloudFormation stack](https://console.aws.amazon.com/cloudformation/home?#/stacks/create/template)
-* Select Template is ready
-* Set Amazon S3 URL depending upon your desired configuration
-  * Private S3 proxy (default):
-    [`https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy.yml`](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy.yml)
-  * Public S3 proxy:
-    [`https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy-public.yml`](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy-public.yml)
-* Click Next
-* Set a stack name up to 32 characters in length. Eg. `shotgun-s3-proxy`
-* Set the parameters that do not have default values with those used when creating the ECR repository, VPC and S3 bucket previously
-* Click Next
-* Accept `I acknowledge that AWS CloudFormation might create IAM resources`
-* Click Next
-
-### Configure HTTPS
-
-ShotGrid requires that the S3 proxy be accessed via HTTPS, therefore the AWS ALB handling requests for your newly created S3 proxy stack must be configured to accept HTTPS requests.
-
-* Create a DNS entry pointing to your S3 proxy, depending upon whether public or private
-  * Private S3 proxy (default):
-    * Go to the [EC2 Load Balancers dashboard](https://console.aws.amazon.com/ec2/home?#LoadBalancers), select your S3 proxy's ALB and make a note of the DNS name
-    * Add a DNS CNAME record pointing to the DNS name of the ALB
-      Eg. `s3-proxy.mystudio.com. 300 IN CNAME s3proxy-12R1MXX0MFFAV-2025360147.us-east-1.elb.amazonaws.com.`
-  * Public S3 proxy:
-    * Go to the [AWS Global Accelerator dashboard](https://console.aws.amazon.com/ec2/v2/home?#GlobalAcceleratorDashboard:) and make a note of the DNS name associated with your S3 proxy's accelerator
-    * Add a DNS CNAME record pointing to the DNS name of the Global Accelerator
-      Eg. `s3-proxy.mystudio.com. 300 IN CNAME a48a2a8de7cfd28d3.awsglobalaccelerator.com.`
-* Obtain an SSL certificate for your chosen URL, we recommend using [AWS Certificate Manager (ACM)](https://aws.amazon.com/certificate-manager/) for this
-* Configure HTTPS for the S3 proxy by adding a new HTTPS listener to the AWS ALB
-  * Go to the [EC2 Load Balancers dashboard](https://console.aws.amazon.com/ec2/home?#LoadBalancers), select your S3 proxy's ALB and click on the Listeners tab
-  * Click Add listener
-  * Select HTTPS from the Protocol dropdown menu
-  * Click Add action -> Forward to...
-  * Select your S3 proxy's target group from the Target group dropdown menu
-  * Select the Security policy you'd like to use. Eg. `TLS-1-2-Ext-2018-06` (See [AWS documentation](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies) for more information)
-  * Select the SSL certificate you'd like to use from ACM or import a new certificate
-  * Click Save
-
-### Add S3 proxy VPC to S3 bucket policy
-
-In order for the S3 proxy to communicate with your S3 bucket your bucket policy must allow access from the S3 proxy's VPC. You can find instructions on how to configure the policy in the [Fine Tuning](./tuning.md#s3-bucket-policy) step.
+In order for the S3 VPC endpoint to communicate with your S3 bucket your bucket policy must allow access from the S3 endpoint's VPC. You can find instructions on how to configure the policy in the [Fine Tuning](./tuning.md#s3-bucket-policy) step.
 
 ## Validation
 
-### Test the S3 proxy
+### Test the S3 VPC endpoint
 
-Try to access your S3 proxy using the ping route. Eg. `https://s3-proxy.mystudio.com/ping`
+Use the endpoint URL to list objects in your bucket using AWS CLI. In the following example, replace the VPC endpoint ID `vpce-1a2b3c4d-5e6f.s3.us-east-1.vpce.amazonaws.com` and bucket name `my-bucket` with appropriate information.
 
-### Configure your test site to use the S3 proxy
+```
+    aws s3 --endpoint-url https://bucket.vpce-1a2b3c4d-5e6f.s3.us-east-1.vpce.amazonaws.com ls s3://my-bucket/
+```
 
-* Navigate to the Site Preferences menu within ShotGrid and expand the Isolation section
+### Configure your test site to use your S3 VPC endpoint
+
+* Navigate to the Site Preferences menu within {% include product %} and expand the Isolation section
 * Set S3 Proxy Host Address to the S3 proxy url. Eg. `https://s3-proxy.mystudio.com` then click Save changes
 * Confirm that you are still able to access existing media
 * Attempt to upload new media

--- a/docs/zh_CN/trusted-solutions/tier1/setup/media_segregation_s3_proxy.md
+++ b/docs/zh_CN/trusted-solutions/tier1/setup/media_segregation_s3_proxy.md
@@ -1,0 +1,137 @@
+---
+layout: default
+title: Media Traffic Isolation - S3 Proxy
+pagename: tier1-setup-media_segregation_s3_proxy
+lang: zh_CN
+---
+
+{% include info title="Deprecated" content="The preferred way is to use S3 Private Link instead of a S3 proxy, see [Media Traffic Isolation](./media_segregation.md)" %}
+
+# Media Traffic Isolation using an S3 proxy (DEPRECATED)
+
+{% include info title="Disclaimer" content="This documentation is provided solely as an example. It explains how to set up your ShotGrid Isolation environment so that it can be connected to ShotGrid cloud infrastructure. Please adapt it to your studio security requirements as needed. As ShotGrid has no visibility on your AWS Account, ensuring that this account is secure is a client responsibility." %}
+
+The media traffic isolation feature allows your users to access media in your AWS S3 bucket privately (not transiting over the public Internet). Please note that if you have a multi-region setup and that leverages the ShotGrid Transcoding service there may still be instances where media transits across the public Internet. Reach out to our support team for more details.
+
+Media Isolation activation is a pre-requisite to enable this feature. If you haven't done so already, see [Media Isolation](./s3_bucket.md).
+
+## Set up a VPC in your S3 bucket AWS region
+
+{% include info title="Disclaimer" content="Before starting, decide whether your S3 proxy will be privately accessible within your VPC or publicly accessible via the Internet and choose the relevant templates in the following instructions." %}
+
+You will need to deploy a VPC with the required VPC endpoints. We provide both [private VPC](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-private-vpc.yml) and [public VPC](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-private-vpc.yml) CloudFormation templates as starting points. These template create the necessary VPCs, subnets and VPC endpoints.
+
+* Create a [new CloudFormation stack](https://console.aws.amazon.com/cloudformation/home?#/stacks/create/template)
+* Select Template is ready
+* Set Amazon S3 URL depending upon your desired configuration
+  * Private VPC (default):
+    [`https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-private-vpc.yml`](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-private-vpc.yml)
+  * Public VPC:
+    [`https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-public-vpc.yml`](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-public-vpc.yml)
+* Click Next
+* Set a stack name. Eg. `shotgun-vpc`
+* Choose network ranges that doesn't conflict with your studio network and set subnet CIDR values accordingly
+* Set your S3 bucket name
+* Click Next
+* Click Next
+
+## Set up access from your site network to your AWS VPC
+
+Options provided by AWS:
+* [AWS Site-to-Site VPN](https://docs.aws.amazon.com/vpn/latest/s2svpn/VPC_VPN.html)
+* [AWS Direct Connect](https://aws.amazon.com/directconnect/)
+
+{% include info title="Note" content="If Direct Connect is chosen, we recommend testing with a simpler / faster solution in the meantime to validate your Isolation setup. You can then replace that solution with Direct Connect once it is available." %}
+
+## Add an S3 endpoint to your VPC
+
+{% include info title="Note" content="This step should only be performed if the CloudFormation template was *not* used when configuring [Media Isolation](./s3_bucket.md)." %}
+
+![Add endpoint](../images/tier1-endpoint-create-1.png)
+![Add endpoint](../images/tier1-endpoint-create-2.png)
+![Add endpoint](../images/tier1-endpoint-create-3.png)
+
+## Set up S3 proxy
+
+You will need to deploy an S3 proxy in your VPC to forward traffic to the S3 VPC endpoint. We provide both [private](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy.yml) and [public](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy-public.yml) S3 proxy CloudFormation templates as starting points for this purpose. These will create the necessary Elastic Container Service (ECS) cluster and other resources to run the S3 proxy on AWS Fargate behind an AWS Application Load Balancer (ALB).
+
+### Make the Docker image available from a private AWS ECR repository
+
+* Create a [new Elastic Container Registry (ECR) repository](https://console.aws.amazon.com/ecr/create-repository)
+* Name the repository `s3-proxy`
+* Upload the s3-proxy Docker image to the newly created ECR repository
+  * [Install Docker](https://docs.docker.com/get-docker/) on your workstation
+  * Follow the `docker login` instructions shown by clicking the *View push commands* button
+  * Run the following commands, substituting the ECR endpoint in the example for yours:
+    ```
+    docker pull quay.io/shotgun/s3-proxy:1.0.6
+    docker tag quay.io/shotgun/s3-proxy:1.0.6 627791357434.dkr.ecr.us-west-2.amazonaws.com/s3-proxy:1.0.6
+    docker push 627791357434.dkr.ecr.us-west-2.amazonaws.com/s3-proxy:1.0.6
+    ```
+
+### Create S3 proxy CloudFormation stack
+
+Create a new stack in AWS Console using either the [private](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy.yml) or [public](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy-public.yml) CloudFormation template.
+
+* Create a [new CloudFormation stack](https://console.aws.amazon.com/cloudformation/home?#/stacks/create/template)
+* Select Template is ready
+* Set Amazon S3 URL depending upon your desired configuration
+  * Private S3 proxy (default):
+    [`https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy.yml`](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy.yml)
+  * Public S3 proxy:
+    [`https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy-public.yml`](https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-s3-proxy-public.yml)
+* Click Next
+* Set a stack name up to 32 characters in length. Eg. `shotgun-s3-proxy`
+* Set the parameters that do not have default values with those used when creating the ECR repository, VPC and S3 bucket previously
+* Click Next
+* Accept `I acknowledge that AWS CloudFormation might create IAM resources`
+* Click Next
+
+### Configure HTTPS
+
+ShotGrid requires that the S3 proxy be accessed via HTTPS, therefore the AWS ALB handling requests for your newly created S3 proxy stack must be configured to accept HTTPS requests.
+
+* Create a DNS entry pointing to your S3 proxy, depending upon whether public or private
+  * Private S3 proxy (default):
+    * Go to the [EC2 Load Balancers dashboard](https://console.aws.amazon.com/ec2/home?#LoadBalancers), select your S3 proxy's ALB and make a note of the DNS name
+    * Add a DNS CNAME record pointing to the DNS name of the ALB
+      Eg. `s3-proxy.mystudio.com. 300 IN CNAME s3proxy-12R1MXX0MFFAV-2025360147.us-east-1.elb.amazonaws.com.`
+  * Public S3 proxy:
+    * Go to the [AWS Global Accelerator dashboard](https://console.aws.amazon.com/ec2/v2/home?#GlobalAcceleratorDashboard:) and make a note of the DNS name associated with your S3 proxy's accelerator
+    * Add a DNS CNAME record pointing to the DNS name of the Global Accelerator
+      Eg. `s3-proxy.mystudio.com. 300 IN CNAME a48a2a8de7cfd28d3.awsglobalaccelerator.com.`
+* Obtain an SSL certificate for your chosen URL, we recommend using [AWS Certificate Manager (ACM)](https://aws.amazon.com/certificate-manager/) for this
+* Configure HTTPS for the S3 proxy by adding a new HTTPS listener to the AWS ALB
+  * Go to the [EC2 Load Balancers dashboard](https://console.aws.amazon.com/ec2/home?#LoadBalancers), select your S3 proxy's ALB and click on the Listeners tab
+  * Click Add listener
+  * Select HTTPS from the Protocol dropdown menu
+  * Click Add action -> Forward to...
+  * Select your S3 proxy's target group from the Target group dropdown menu
+  * Select the Security policy you'd like to use. Eg. `TLS-1-2-Ext-2018-06` (See [AWS documentation](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies) for more information)
+  * Select the SSL certificate you'd like to use from ACM or import a new certificate
+  * Click Save
+
+### Add S3 proxy VPC to S3 bucket policy
+
+In order for the S3 proxy to communicate with your S3 bucket your bucket policy must allow access from the S3 proxy's VPC. You can find instructions on how to configure the policy in the [Fine Tuning](./tuning.md#s3-bucket-policy) step.
+
+## Validation
+
+### Test the S3 proxy
+
+Try to access your S3 proxy using the ping route. Eg. `https://s3-proxy.mystudio.com/ping`
+
+### Configure your test site to use the S3 proxy
+
+* Navigate to the Site Preferences menu within ShotGrid and expand the Isolation section
+* Set S3 Proxy Host Address to the S3 proxy url. Eg. `https://s3-proxy.mystudio.com` then click Save changes
+* Confirm that you are still able to access existing media
+* Attempt to upload new media
+
+## Next Steps
+
+See [Web Traffic Isolation](./traffic_segregation.md) to activate the Web Traffic Isolation feature.
+
+See [Media Replication](./s3_replication.md) to activate the Web Traffic Isolation feature.
+
+Go to [Setup](./setup.md) for an overview of the possible next steps.

--- a/docs/zh_CN/trusted-solutions/tier1/setup/migration.md
+++ b/docs/zh_CN/trusted-solutions/tier1/setup/migration.md
@@ -2,7 +2,7 @@
 layout: default
 title: Migration
 pagename: tier1-setup-migration
-lang: en
+lang: zh_CN
 ---
 
 # Migration
@@ -11,17 +11,17 @@ Once everything is configured and properly tested with the migration test site, 
 
 ## Test migration
 
-Ask the ShotGrid team to start the migration process in support ticket/slack.
+Ask the {% include product %} team to start the migration process in support ticket/slack.
 
-  * ShotGrid will clone your production site database to your migration test site.
-  * You will do a first sync of the media from ShotGrid's S3 bucket to your bucket. ShotGrid will provide the exact instructions.
+  * {% include product %} will clone your production site database to your migration test site.
+  * You will do a first sync of the media from {% include product %}'s S3 bucket to your bucket. {% include product %} will provide the exact instructions.
   * You can now test your site to be sure your existing media is available.
 
 ## Final migration
 
 The second test is to definitly migrate your site to use your own S3 bucket.
 
-  * You will do a second sync of the media from ShotGrid's S3 bucket to your bucket.
-  * ShotGrid will reconfigure your hosted site with media isolation. Some media will be missing until the final media sync is completed.
+  * You will do a second sync of the media from {% include product %}'s S3 bucket to your bucket.
+  * {% include product %} will reconfigure your hosted site with media isolation. Some media will be missing until the final media sync is completed.
   * You will do a final media sync.
 

--- a/docs/zh_CN/trusted-solutions/tier1/setup/planning.md
+++ b/docs/zh_CN/trusted-solutions/tier1/setup/planning.md
@@ -2,7 +2,7 @@
 layout: default
 title: Planning Your Setup
 pagename: tier1-getting_started-planning
-lang: en
+lang: zh_CN
 ---
 
 # Planning Your Setup
@@ -45,7 +45,7 @@ If you plan to activate any of the Traffic Isolation feature, you will need a wa
   * AWS Direct Connect
   * Other VPN solution
 
-We highly recommand you to leverage Direct Connect. Direct Connect guarantees the lowest latency possible to the ShotGrid services, a consistent network experience, and allow you to leverage the optimization AWS is relying on to guarantee an optimal performance across the globe.
+We highly recommand you to leverage Direct Connect. Direct Connect guarantees the lowest latency possible to the {% include product %} services, a consistent network experience, and allow you to leverage the optimization AWS is relying on to guarantee an optimal performance across the globe.
 
 ## Next Step
 

--- a/docs/zh_CN/trusted-solutions/tier1/setup/s3_bucket.md
+++ b/docs/zh_CN/trusted-solutions/tier1/setup/s3_bucket.md
@@ -2,7 +2,7 @@
 layout: default
 title: Media Isolation
 pagename: tier1-setup-s3_bucket
-lang: en
+lang: zh_CN
 ---
 
 # Media Isolation
@@ -24,8 +24,8 @@ It's possible to start from the [Private S3 bucket AWS CloudFormation template](
   * Select Template is ready
   * Set Amazon S3 URL to https://sg-shotgunsoftware.s3-us-west-2.amazonaws.com/tier1/cloudformation_templates/sg-private-s3-bucket.yml
   * Next
-  * Set a stack name like shotgun-s3-bucket
-  * Set your S3 bucket name and your ShotGrid site name
+  * Set a stack name like {% include product %}-s3-bucket
+  * Set your S3 bucket name and your {% include product %} site name
   * Next
   * Accept `I acknowledge that AWS CloudFormation might create IAM resources`
   * Next
@@ -38,28 +38,28 @@ CORS policy on your S3 bucket will be minimally configured, allowing only the re
 
 The template will create an AWS Role with the following permissions on your bucket:
 
-* Allow ShotGrid to access your S3 bucket.
-* Allow the ShotGrid account to assume the role by setting the role Trust Relationship.
+* Allow {% include product %} to access your S3 bucket.
+* Allow the {% include product %} account to assume the role by setting the role Trust Relationship.
 
 ## Media Isolation Activation
 
-Please contact ShotGrid support via the dedicated Slack channel and provide the following information:
+Please contact {% include product %} support via the dedicated Slack channel and provide the following information:
   * S3 bucket name
   * AWS Region
-  * ShotGrid Role ARN
+  * {% include product %} Role ARN
 
-ShotGrid will configure your test site to use your own S3 bucket.
+{% include product %} will configure your test site to use your own S3 bucket.
 
 ## Validation
 
-At this stage, you should be able to upload and download media. The ShotGrid Transcoding Service should also be able to read, transcode and write back the thumbnails, filmstrip and web friendly versions of your media back to your S3 Bucket. To validate this:
+At this stage, you should be able to upload and download media. The {% include product %} Transcoding Service should also be able to read, transcode and write back the thumbnails, filmstrip and web friendly versions of your media back to your S3 Bucket. To validate this:
 
 1. Log in your Migration Test Site.
 2. From the Navigation Bar, go the the Media app
 3. Once in the Media App, drag and drop or upload an image or a video from your computer. If you didn't created a Project yet, you may have to create one first.
 4. A version should appear, with a thumbnail, in the Media App.
 5. Validate that you can playback the media by clicking the Play button.
-6. To validate that the media has been stored in your S3 bucket, from the media viewer, click on the cog and then select or hover over view source view. The HTTPS link should contain your bucket name.
+6. To validate that the media has been stored in your S3 bucket, from the media viewer, click on the cog and then select or hover over ‘view source’. The HTTPS link should contain your bucket name.
 
 ## Next Steps
 

--- a/docs/zh_CN/trusted-solutions/tier1/setup/s3_replication.md
+++ b/docs/zh_CN/trusted-solutions/tier1/setup/s3_replication.md
@@ -2,14 +2,14 @@
 layout: default
 title: Media Replication
 pagename: tier1-setup-s3_replication
-lang: en
+lang: zh_CN
 ---
 
 # Media Replication
 
 ## Description
 
-It's possible to add S3 replication between two S3 buckets in different regions and configure ShotGrid to leverage it for faster access to media.
+It's possible to add S3 replication between two S3 buckets in different regions and configure {% include product %} to leverage it for faster access to media.
 
 ![S3 Replication Diagram](../images/tier1-s3-replication.png)
 
@@ -40,10 +40,10 @@ The `IP Adresses for S3 replication` preference can be edited in Site Preference
 # Setup steps
 
   * Create the replica S3 bucket in a new AWS region. See [Media Isolation](./s3_bucket.md)
-  * Update your existing ShotGrid role policy to allow ShotGrid to also access the replica bucket
+  * Update your existing {% include product %} role policy to allow {% include product %} to also access the replica bucket
   * Setup the replication rules on the primary S3 bucket. See [How do I add a replication rule to an S3 bucket?](https://docs.aws.amazon.com/AmazonS3/latest/user-guide/enable-replication.html#enable-replication-add-rule)
   * Setup a VPC + Direct Connect + S3 proxy in the new AWS region. See [Media Traffic Isolation](./media_segregation.md)
-  * Contact ShotGrid Support to configure your site to use the new S3 replica bucket, providing the following information:
+  * Contact {% include product %} Support to configure your site to use the new S3 replica bucket, providing the following information:
     * Replica Bucket Name
     * Replica Bucket Region
     * Replica S3 proxy URL

--- a/docs/zh_CN/trusted-solutions/tier1/setup/setup.md
+++ b/docs/zh_CN/trusted-solutions/tier1/setup/setup.md
@@ -2,10 +2,10 @@
 layout: default
 title: Setup
 pagename: tier1-setup
-lang: en
+lang: zh_CN
 ---
 
-# ShotGrid Isolation Feature Set - Setup
+# {% include product %} Isolation Feature Set - Setup
 
 Isolation the isolation features are independent of each other, and can be activated independently of each other. Media replication have as pre-requisite for Media Isolation to be implemented.
 
@@ -40,7 +40,7 @@ Before you start working on your setup, [put a plan in place](./planning.md). Ch
 
 ## [Migration Test Site](./shotgun_poc_site.md)
 
-To help you setting up the Isolation features without breaking your production environment and to helping smooting the migration to your isolated environment, ShotGrid propose to use a test site on which to test your setup before applying the result to production.
+To help you setting up the Isolation features without breaking your production environment and to helping smooting the migration to your isolated environment, {% include product %} propose to use a test site on which to test your setup before applying the result to production.
 
 ## [Media Isolation](./s3_bucket.md)
 

--- a/docs/zh_CN/trusted-solutions/tier1/setup/shotgun_poc_site.md
+++ b/docs/zh_CN/trusted-solutions/tier1/setup/shotgun_poc_site.md
@@ -2,14 +2,14 @@
 layout: default
 title: Migration Test Site
 pagename: tier1-setup-shotgun_poc_site
-lang: en
+lang: zh_CN
 ---
 
-# ShotGrid Migration Test Site
+# {% include product %} Migration Test Site
 
 Activating the isolation feature set is an intrusive procedure that can have an impact on the usability of your site. To prevent a production stopping event, we require clients to follow an approach where the configuration is first validated on a test site, before being applied to the production site.
 
-The ShotGrid team will create a temporary site to be used as a Proof of Concept for your ShotGrid Isolation deployment. Upon the successful completion of the setup process, your existing ShotGrid site can be migrated to your ShotGrid Isolation environment.
+The {% include product %} team will create a temporary site to be used as a Proof of Concept for your {% include product %} Isolation deployment. Upon the successful completion of the setup process, your existing {% include product %} site can be migrated to your {% include product %} Isolation environment.
 
 If your Migration Test Site has not been created yet, please reach out to our Support team through your Zendesk ticket or your dedicated on-boarding Slack Channel.
 

--- a/docs/zh_CN/trusted-solutions/tier1/setup/traffic_segregation.md
+++ b/docs/zh_CN/trusted-solutions/tier1/setup/traffic_segregation.md
@@ -2,31 +2,31 @@
 layout: default
 title: Web Traffic Isolation
 pagename: tier1-setup-traffic_segregation
-lang: en
+lang: zh_CN
 ---
 
 # Web Traffic Isolation
 
-The goal is to set up an AWS PrivateLink to privately access your ShotGrid site.
+The goal is to set up an AWS PrivateLink to privately access your {% include product %} site.
 
 ## Set up PrivateLink to ShotGrid
 
-  * Ask ShotGrid support to provide you with the ShotGrid PrivateLink service name for your AWS region.
+  * Ask {% include product %} support to provide you with the {% include product %} PrivateLink service name for your AWS region.
 
-  * Update the private VPC CloudFormation stack you created earlier and set ShotgunPrivateServiceName parameter.
+  * Update the private VPC CloudFormation stack you created earlier and set {% include product %}PrivateServiceName parameter.
 
 ### Manual steps if needed
 
   * Add a new VPC Endpoint in your VPC
 
-  * For the security group, ShotGrid service only requires the inbound port tcp/443 to be open.
+  * For the security group, {% include product %} service only requires the inbound port tcp/443 to be open.
 
 ![Create endpoint](../images/tier1-endpoint-create_privatelink.png)
 
 
 ## DNS Configuration
 
-Provide your PrivateLink DNS name to ShotGrid support. We will setup a new private URL for your site that will look like `mystudio-staging.priv.shotgunstudio.com`.
+Provide your PrivateLink DNS name to {% include product %} support. We will setup a new private URL for your site that will look like `mystudio-staging.priv.shotgunstudio.com`.
 
 ## Validation
 

--- a/docs/zh_CN/trusted-solutions/tier1/setup/tuning.md
+++ b/docs/zh_CN/trusted-solutions/tier1/setup/tuning.md
@@ -2,7 +2,7 @@
 layout: default
 title: Fine Tuning
 pagename: tier1-setup-tuning
-lang: en
+lang: zh_CN
 ---
 
 # Fine Tuning
@@ -11,17 +11,17 @@ lang: en
 
 ### S3 Infrequent Access
 
-We recommend enabling S3 Infrequent Access to easily reduce costs without impacting performance. For the ShotGrid Cloud hosted offering, we apply a policy for all objects older than one month.
+We recommend enabling S3 Infrequent Access to easily reduce costs without impacting performance. For the {% include product %} Cloud hosted offering, we apply a policy for all objects older than one month.
 
-With Infrequent Access, objects are stored at a lower cost. However, if they are accessed, it will involve an additional cost. ShotGrid has observed that one month was the right policy to use globally, but you may want to adapt that policy to your studio workflows as needed.
+With Infrequent Access, objects are stored at a lower cost. However, if they are accessed, it will involve an additional cost. {% include product %} has observed that one month was the right policy to use globally, but you may want to adapt that policy to your studio workflows as needed.
 
 Read more about S3 Infrequent Access and other storage classes [here](https://aws.amazon.com/s3/storage-classes/).
 
 ## S3 Bucket policy
 
-We recommend you restrict access to your S3 bucket to only your VPC and ShotGrid transcoding services IPs. There is an example policy, replace `your_vpc_id` and `your_s3_bucket` by your values.
+We recommend you restrict access to your S3 bucket to only your VPC and {% include product %} transcoding services IPs. There is an example policy, replace `your_vpc_id` and `your_s3_bucket` by your values.
 
-We strongly recommend you test media access and media transcoding in your migration test site right after applying the bucket policy changes to be sure your S3 bucket is still accessible from your VPC and from ShotGrid transcoders.
+We strongly recommend you test media access and media transcoding in your migration test site right after applying the bucket policy changes to be sure your S3 bucket is still accessible from your VPC and from {% include product %} transcoders.
 
 ```
 {
@@ -59,6 +59,7 @@ We strongly recommend you test media access and media transcoding in your migrat
                 },
                 "StringNotEquals": {
                     "aws:sourceVpc": [
+                        "vpc-2fd62a56",
                         "your_vpc_id"
                     ]
                 }


### PR DESCRIPTION
The translation files in the `trusted-solutions` section had lagged behind their English sources, but had not yet been translated and still had `lang: en` in their headers.

* Update the headers to reflect the target language
* Update the i18n files to reflect the changes in their sources