### PR TITLE
Replace ShotGrid_API_CACERTS with SHOTGUN_API_CACERTS

### DIFF
--- a/docs/en/quick-answers/troubleshooting/fix-ssl-certificate-verify-failed.md
+++ b/docs/en/quick-answers/troubleshooting/fix-ssl-certificate-verify-failed.md
@@ -34,7 +34,7 @@ Add the required CA certificate to the Windows Certificate Store. Windows 7 user
 
 1. Upgrade to the Python API **v3.0.39**
 
-2. a. Set `{% include product %}_API_CACERTS` to `/path/to/shotgun_api3/lib/httplib2/cacerts.txt`
+2. a. Set `SHOTGUN_API_CACERTS` to `/path/to/shotgun_api3/lib/httplib2/cacerts.txt`
 
    or
    
@@ -47,7 +47,7 @@ the `core/core_api.yml` file of your pipeline configuration, depending on how yo
 
 2. Download an up-to-date list of certificates at [https://github.com/certifi/python-certifi/blob/master/certifi/cacert.pem](https://github.com/certifi/python-certifi/blob/master/certifi/cacert.pem).
 
-3. Set `{% include product %}_API_CACERTS` to the location where you saved this file. Toolkit doesn’t allow you to specify the `ca_certs` parameter when creating connections the way the Python API does.
+3. Set `SHOTGUN_API_CACERTS` to the location where you saved this file. Toolkit doesn’t allow you to specify the `ca_certs` parameter when creating connections the way the Python API does.
 
 ### If you can’t update the Python API or Toolkit
 

--- a/docs/ja/quick-answers/troubleshooting/fix-ssl-certificate-verify-failed.md
+++ b/docs/ja/quick-answers/troubleshooting/fix-ssl-certificate-verify-failed.md
@@ -34,7 +34,7 @@ Windows 証明書ストアに必要な CA 証明書を追加します。Windows 
 
 1. Python API **v3.0.39** にアップグレードします。
 
-2. a. `{% include product %}_API_CACERTS` を `/path/to/shotgun_api3/lib/httplib2/cacerts.txt` に設定します。
+2. a. `SHOTGUN_API_CACERTS` を `/path/to/shotgun_api3/lib/httplib2/cacerts.txt` に設定します。
 
    または
 
@@ -46,7 +46,7 @@ Windows 証明書ストアに必要な CA 証明書を追加します。Windows 
 
 2. [https://github.com/certifi/python-certifi/blob/master/certifi/cacert.pem](ttps://github.com/certifi/python-certifi/blob/master/certifi/cacert.pem) にある証明書の最新リストをダウンロードします。
 
-3. `{% include product %}_API_CACERTS` をこのファイルの保存場所に設定します。ただし、接続を作成するときに、Python API のように Toolkit から `ca_certs`ca_certs パラメータを指定することはできません。
+3. `SHOTGUN_API_CACERTS` をこのファイルの保存場所に設定します。ただし、接続を作成するときに、Python API のように Toolkit から `ca_certs`ca_certs パラメータを指定することはできません。
 
 ### Python API または Toolkit を更新できない場合
 

--- a/docs/ko/quick-answers/troubleshooting/fix-ssl-certificate-verify-failed.md
+++ b/docs/ko/quick-answers/troubleshooting/fix-ssl-certificate-verify-failed.md
@@ -34,7 +34,7 @@ Python API는 최신 인증서 사본을 제공하지만 2019년 2월 21일부�
 
 1. Python API **v3.0.39**로 업그레이드합니다.
 
-2. a. `{% include product %}_API_CACERTS`를 `/path/to/shotgun_api3/lib/httplib2/cacerts.txt`로 설정합니다.
+2. a. `SHOTGUN_API_CACERTS`를 `/path/to/shotgun_api3/lib/httplib2/cacerts.txt`로 설정합니다.
 
    또는
 
@@ -46,7 +46,7 @@ Python API는 최신 인증서 사본을 제공하지만 2019년 2월 21일부�
 
 2. [https://github.com/certifi/python-certifi/blob/master/certifi/cacert.pem](ttps://github.com/certifi/python-certifi/blob/master/certifi/cacert.pem)에서 최신 인증서 목록을 다운로드합니다.
 
-3. `{% include product %}_API_CACERTS`를 이 파일을 저장한 위치로 설정합니다. 하지만 툴킷은 Python API에서처럼 연결을 만들 때 `ca_certs` 매개변수 지정을 허용하지 않습니다.
+3. `SHOTGUN_API_CACERTS`를 이 파일을 저장한 위치로 설정합니다. 하지만 툴킷은 Python API에서처럼 연결을 만들 때 `ca_certs` 매개변수 지정을 허용하지 않습니다.
 
 ### Python API 또는 툴킷을 업데이트할 수 없는 경우
 

--- a/docs/zh_CN/quick-answers/troubleshooting/fix-ssl-certificate-verify-failed.md
+++ b/docs/zh_CN/quick-answers/troubleshooting/fix-ssl-certificate-verify-failed.md
@@ -34,7 +34,7 @@ Python API 依赖与 API 捆绑在一起且位于计算机上的一组证书才�
 
 1. 升级到 Python API **v3.0.39**
 
-2. a. 将 `{% include product %}_API_CACERTS` 设置为 `/path/to/shotgun_api3/lib/httplib2/cacerts.txt`
+2. a. 将 `SHOTGUN_API_CACERTS` 设置为 `/path/to/shotgun_api3/lib/httplib2/cacerts.txt`
 
    或
 
@@ -46,7 +46,7 @@ Python API 依赖与 API 捆绑在一起且位于计算机上的一组证书才�
 
 2. 从 [https://github.com/certifi/python-certifi/blob/master/certifi/cacert.pem](ttps://github.com/certifi/python-certifi/blob/master/certifi/cacert.pem) 下载最新的证书列表。
 
-3. 将 `{% include product %}_API_CACERTS` 设置为该文件的保存位置。与 Python API 类似，Toolkit 不允许您在创建连接时指定 `ca_certs` 参数。
+3. 将 `SHOTGUN_API_CACERTS` 设置为该文件的保存位置。与 Python API 类似，Toolkit 不允许您在创建连接时指定 `ca_certs` 参数。
 
 ### 如果无法更新 Python API 或 Toolkit
 


### PR DESCRIPTION
Replace references to {% include product %}_API_CACERTS with hardcoded string SHOTGUN_API_CACERTS.

![image](https://user-images.githubusercontent.com/2762494/129919379-bb76941c-7232-438a-b042-f635a67bf479.png)
