### PR TITLE
Force Bundler version `1.17.2` to match Docker configuration

### DIFF
--- a/.github/workflows/generate-preview.yml
+++ b/.github/workflows/generate-preview.yml
@@ -21,9 +21,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.6
-          # Force bundler to 1.17.2 -- this matches the Dockerfile configuration
-          # but more importantly, using a newer bundler version seems to trigger
-          # a regression in the i18n of images.
+          # Force bundler to 1.17.2 to match the Dockerfile configuration
           bundler: 1.17.2
       - name: Install Pandoc
         run: sudo apt-get install -y pandoc

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -24,6 +24,8 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.6
+          # Force bundler to 1.17.2 to match the Dockerfile configuration
+          bundler: 1.17.2
       - name: Install Pandoc
         run: sudo apt-get install -y pandoc
       - name: Install Jekyll dependencies


### PR DESCRIPTION
The default bundler version provided by `ruby-setup` doesn't match the version specified for Docker or Travis.  This appeared to lead to a regression in the i18n for images.