### PR TITLE
Add config step for bundle in publish docs workflow

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -26,8 +26,10 @@ jobs:
           ruby-version: 2.6
       - name: Install Pandoc
         run: sudo apt-get install -y pandoc
+      - name: Bundle config
+        run: bundle config set --local deployment 'true'
       - name: Install Jekyll dependencies
-        run: bundle install --gemfile=./tk-doc-generator/Gemfile --deployment
+        run: bundle install --gemfile=./tk-doc-generator/Gemfile
       - name: Install tk-doc-generator requirements
         run: pip install -r ./tk-doc-generator/requirements.txt
       - name: Generate HTML


### PR DESCRIPTION
This PR adds a new step **Bundle config** in the Github Action **Publish-Docs** to remove deprecated flag **--deployment** when building the docs.

The usage of this deprecated flag was causing that commands like **jekyll** were not found.

The deprecation message was:

```
[DEPRECATED] The `--deployment` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set --local deployment 'true'`, and stop using this flag
```
The jekyll command not found was:

```
bundler: command not found: jekyll
```